### PR TITLE
Setting SALT deduction to zero

### DIFF
--- a/policyengine_taxsim/cli.py
+++ b/policyengine_taxsim/cli.py
@@ -21,7 +21,8 @@ except ImportError:
     help="Output file path",
 )
 @click.option('--logs', is_flag=True, help='Generate PE YAML Tests Logs')
-def main(input_file, output, logs):
+@click.option('--disable-salt', is_flag=True, default=False, help='Set Salt Deduction to 0.0')
+def main(input_file, output, logs, disable_salt):
     """
     Process TAXSIM input file and generate PolicyEngine-compatible output.
     """
@@ -39,13 +40,13 @@ def main(input_file, output, logs):
             pe_situation = generate_household(taxsim_input)
             idtl = taxsim_input['idtl']
             if idtl == 0:
-                taxsim_output = export_household(taxsim_input, pe_situation, logs)
+                taxsim_output = export_household(taxsim_input, pe_situation, logs, disable_salt)
                 idtl_0_results.append(taxsim_output)
             elif idtl == 2:
-                taxsim_output = export_household(taxsim_input, pe_situation, logs)
+                taxsim_output = export_household(taxsim_input, pe_situation, logs, disable_salt)
                 idtl_2_results.append(taxsim_output)
             else:
-                taxsim_output = export_household(taxsim_input, pe_situation, logs)
+                taxsim_output = export_household(taxsim_input, pe_situation, logs, disable_salt)
                 idtl_5_results += taxsim_output
 
         # Create output dataframe and save to csv

--- a/policyengine_taxsim/core/output_mapper.py
+++ b/policyengine_taxsim/core/output_mapper.py
@@ -5,6 +5,7 @@ from .utils import (
 from policyengine_us import Simulation
 from policyengine_tests_generator.core.generator import PETestsYAMLGenerator
 
+disable_salt_variable = False
 
 def generate_non_description_output(taxsim_output, mappings, year, state_name, simulation, output_type, logs):
     outputs = []
@@ -274,7 +275,7 @@ def add_a_dollar(data):
     return data
 
 
-def export_household(taxsim_input, policyengine_situation, logs):
+def export_household(taxsim_input, policyengine_situation, logs, disable_salt):
     """
     Convert a PolicyEngine situation to TAXSIM output variables.
 
@@ -284,6 +285,9 @@ def export_household(taxsim_input, policyengine_situation, logs):
     Returns:
         dict: Dictionary of TAXSIM output variables
     """
+    global disable_salt_variable
+    disable_salt_variable = disable_salt
+
     mappings = load_variable_mappings()["policyengine_to_taxsim"]
 
     simulation = Simulation(situation=policyengine_situation)
@@ -316,7 +320,8 @@ def export_household(taxsim_input, policyengine_situation, logs):
 
 def simulate(simulation, variable, year):
     try:
-        simulation.set_input(variable_name='salt_deduction', value=0.0)
+        if disable_salt_variable:
+            simulation.set_input(variable_name='salt_deduction', value=0.0)
         return to_roundedup_number(simulation.calculate(variable, period=year))
     except Exception as error:
         return 0.00
@@ -324,7 +329,8 @@ def simulate(simulation, variable, year):
 
 def simulate_multiple(simulation, variables, year):
     try:
-        simulation.set_input(variable_name='salt_deduction', value=0.0)
+        if disable_salt_variable:
+            simulation.set_input(variable_name='salt_deduction', value=0.0)
         total = sum(to_roundedup_number(simulation.calculate(variable, period=year)) for variable in variables)
     except Exception as error:
         total = 0.00

--- a/policyengine_taxsim/core/output_mapper.py
+++ b/policyengine_taxsim/core/output_mapper.py
@@ -316,6 +316,7 @@ def export_household(taxsim_input, policyengine_situation, logs):
 
 def simulate(simulation, variable, year):
     try:
+        simulation.set_input(variable_name='salt_deduction', value=0.0)
         return to_roundedup_number(simulation.calculate(variable, period=year))
     except Exception as error:
         return 0.00
@@ -323,6 +324,7 @@ def simulate(simulation, variable, year):
 
 def simulate_multiple(simulation, variables, year):
     try:
+        simulation.set_input(variable_name='salt_deduction', value=0.0)
         total = sum(to_roundedup_number(simulation.calculate(variable, period=year)) for variable in variables)
     except Exception as error:
         total = 0.00


### PR DESCRIPTION
set `salt_deduction` 0.0 from cli argument 

`python policyengine_taxsim\cli.py input.csv --disable-salt`

Fixes #160 
