### PR TITLE
Use unified state variables instead of per-state iteration

### DIFF
--- a/changelog.d/unified-state-vars.added.md
+++ b/changelog.d/unified-state-vars.added.md
@@ -1,0 +1,1 @@
+Use unified state variables instead of per-state iteration for ~10x fewer calculation calls. Add CPS-like benchmark (2000 records, all states, full output).


### PR DESCRIPTION
## Summary

Follow-up to #692. The vectorized extract still iterated over all unique states for variables like `state_agi`, `state_eitc`, etc. — but these already exist as unified PE variables that use `defined_for` to return correct per-state values in a single `sim.calculate()` call.

- Check if the unified PE variable exists before falling into per-state iteration
- Call unified variables directly (one call instead of ~50 per variable)
- Falls back to per-state iteration only for variables without a unified PE equivalent
- Reduces `_calc_tax_unit` calls from ~370 to ~33 (11x fewer) for all-state data
- Adds test for call count and value correctness

## Test plan

- [x] All 29 tests pass (12 e2e + 8 mapper + 9 performance)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)