### PR TITLE
Require policyengine-us >= 1.552.0 for deterministic results

### DIFF
--- a/changelog.d/pin-deterministic-us.changed.md
+++ b/changelog.d/pin-deterministic-us.changed.md
@@ -1,0 +1,1 @@
+Require policyengine-us >= 1.552.0 to ensure deterministic results (no random takeup draws in the country package).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "policyengine-us",
+    "policyengine-us>=1.552.0",
     "pandas",
     "PyYAML",
     "click",


### PR DESCRIPTION
## Summary
- Pin policyengine-us >= 1.552.0, which moved all stochastic randomness (SNAP, Medicaid, ACA, WIC takeup draws) from the country package to the data package
- Ensures policyengine-taxsim always produces deterministic results for the same inputs — no seed needed

Prompted by BEA reporting non-deterministic results across runs.

## Test plan
- [ ] CI passes with the new pin
- [ ] Verify same inputs produce identical outputs across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)