### PR TITLE
Pin Python version in R wrapper setup

### DIFF
--- a/changelog.d/fix-setup-python-version.fixed.md
+++ b/changelog.d/fix-setup-python-version.fixed.md
@@ -1,0 +1,1 @@
+Pin Python version constraint in R wrapper setup_policyengine() to avoid failure on Python 3.14+ machines.


### PR DESCRIPTION
## Summary

- `setup_policyengine()` now constrains the virtualenv to `Python >=3.10,<3.14`, matching the `policyengine-us` PyPI requirement
- On machines with only Python 3.14 (current stable), setup previously failed silently at the pip install step
- Adds clear error messages directing users to install Python 3.12 if no compatible version is found

## Context

The Living Wage Calculator team bypassed `setup_policyengine()` entirely and wrote an 8-step manual installation guide — largely because `setup_policyengine()` doesn't handle the Python version constraint. On a fresh machine with Python 3.14, `reticulate::virtualenv_create()` picks up 3.14, then `pip install policyengine-us` fails because policyengine-us requires `<3.14`.

## Changes

In `r-package/policyenginetaxsim/R/setup.R`:
- Added `.PE_PYTHON_VERSION` constant (`">=3.10,<3.14"`) matching the policyengine-us constraint
- `virtualenv_create()` now passes `version = .PE_PYTHON_VERSION` to select a compatible Python
- Pre-checks for compatible Python using `virtualenv_starter()` before attempting venv creation
- Error messages now explain the version requirement and suggest `brew install python@3.12`

Closes #707

## Test plan

- [ ] Verify `setup_policyengine(force = TRUE)` works on machine with Python 3.12/3.13
- [ ] Verify error message is clear on machine with only Python 3.14
- [ ] Verify `policyengine_calculate_taxes()` works end-to-end after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)