### PR TITLE
Handle ParameterNotFoundError gracefully in runner

### DIFF
--- a/changelog.d/fix-runner-parameter-not-found.fixed.md
+++ b/changelog.d/fix-runner-parameter-not-found.fixed.md
@@ -1,0 +1,1 @@
+Handle missing parameter errors gracefully in PolicyEngineRunner instead of crashing.

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -1043,7 +1043,7 @@ class PolicyEngineRunner(BaseTaxRunner):
                                             arr = self._calc_tax_unit(sim, resolved, year_str)
                                             var_sum += arr
                                         except Exception as e:
-                                            if "does not exist" in str(e):
+                                            if "does not exist" in str(e) or "was not found" in str(e):
                                                 if self.logs:
                                                     print(
                                                         f"Variable {resolved} not implemented, setting to 0"
@@ -1061,7 +1061,7 @@ class PolicyEngineRunner(BaseTaxRunner):
                                         arr = self._calc_tax_unit(sim, resolved, year_str)
                                         result_array[state_mask] = arr[state_mask]
                                     except Exception as e:
-                                        if "does not exist" in str(e):
+                                        if "does not exist" in str(e) or "was not found" in str(e):
                                             if self.logs:
                                                 print(
                                                     f"Variable {resolved} not implemented, setting to 0"
@@ -1085,7 +1085,8 @@ class PolicyEngineRunner(BaseTaxRunner):
                         columns[taxsim_var] = np.round(arr, 2)
 
                 except Exception as e:
-                    if "does not exist" in str(e):
+                    err_msg = str(e)
+                    if "does not exist" in err_msg or "was not found" in err_msg:
                         if self.logs:
                             print(
                                 f"Variable {pe_var} not implemented, setting to 0"


### PR DESCRIPTION
## Summary

- Runner crashed on PA records (2024) because `state_eitc` triggers a `ParameterNotFoundError` for `pa_eitc.match`
- The error handler only caught `"does not exist"` but not `"was not found"` — now catches both
- Matches exe.py behavior: returns 0 for missing parameters instead of crashing

## Context

Found while testing the runner as a replacement for exe.py in response to #706 (speed issue). Without this fix, any input containing Pennsylvania records for 2024 crashes the runner.

## Test plan

- [x] Tested all 51 states individually in a fresh venv with policyengine-us 1.570.7
- [x] Tested 1000 records across all states — completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)