### PR TITLE
Update Stata examples to match TAXSIM conventions

### DIFF
--- a/changelog.d/update-stata-examples.changed.md
+++ b/changelog.d/update-stata-examples.changed.md
@@ -1,0 +1,1 @@
+Update Stata code examples on landing page and docs to use idiomatic TAXSIM conventions (! shell escape, txpydata.raw/output.raw filenames, explicit delimiter).

--- a/dashboard/src/components/DocumentationContent.jsx
+++ b/dashboard/src/components/DocumentationContent.jsx
@@ -110,9 +110,9 @@ result <- policyengine_calculate_taxes(my_data)`,
       label: 'R',
     },
     stata: {
-      code: `export delimited using "input.csv", replace
-shell policyengine-taxsim < input.csv > output.csv
-import delimited using "output.csv", clear`,
+      code: `export delimited using "txpydata.raw", delimiter(",") replace
+! policyengine-taxsim < txpydata.raw > output.raw
+import delimited using "output.raw", delimiter(",") clear`,
       language: 'stata',
       label: 'Stata',
     },

--- a/dashboard/src/components/LandingContent.jsx
+++ b/dashboard/src/components/LandingContent.jsx
@@ -110,7 +110,7 @@ const COMPARISON_EXAMPLES = {
     },
     after: {
       label: 'Stata',
-      code: 'export delimited using "input.csv", replace\nshell policyengine-taxsim < input.csv > output.csv\nimport delimited using "output.csv", clear',
+      code: 'export delimited using "txpydata.raw", delimiter(",") replace\n! policyengine-taxsim < txpydata.raw > output.raw\nimport delimited using "output.raw", delimiter(",") clear',
       language: 'stata',
     },
   },


### PR DESCRIPTION
## Summary
- Updates Stata code examples on landing page and documentation to use idiomatic TAXSIM conventions per Dan Feenberg's feedback
- Uses `!` shell escape instead of `shell`, canonical `txpydata.raw`/`output.raw` filenames, and explicit `delimiter(",")` on export/import

## Test plan
- [ ] Verify landing page Stata tab renders correctly
- [ ] Verify documentation page Stata tab renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)