### PR TITLE
Update install instructions to use uv

### DIFF
--- a/cps-dashboard/src/components/Documentation.jsx
+++ b/cps-dashboard/src/components/Documentation.jsx
@@ -123,7 +123,7 @@ import delimited using "output.csv", clear`,
         label: 'Pin policyengine-us version (optional)',
         language: 'cli',
         code: `# For reproducible results, pin the underlying tax model version
-pip install policyengine-us==1.555.0`
+uv pip install policyengine-us==1.555.0`
       },
       {
         id: 'python-cli-advanced',
@@ -409,7 +409,7 @@ policyengine_versions()
             <div className="doc-intro-blurb">
               The PolicyEngine TAXSIM Emulator supports <strong>all input and output variables</strong> provided
               by TAXSIM35. It's a <strong>drop-in replacement</strong> — install
-              with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>pip install policyengine-taxsim</code> and
+              with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>uv pip install policyengine-taxsim</code> and
               swap <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>taxsim35</code> for <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>policyengine-taxsim</code>.
               Like TAXSIM35, this emulator <strong>runs entirely on your machine</strong>.
               Use the same CSV format you already know: provide household demographics,
@@ -447,11 +447,14 @@ policyengine_versions()
               <h3 style={{ fontSize: '1.1rem', fontWeight: 700, color: 'var(--darkest-blue)', marginBottom: '12px' }}>
                 Installation
               </h3>
+              <p style={{ color: 'var(--dark-gray)', marginBottom: '12px', fontSize: '14px', lineHeight: '1.7' }}>
+                Requires <a href="https://docs.astral.sh/uv/getting-started/installation/" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue-primary)' }}>uv</a> (install with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>curl -LsSf https://astral.sh/uv/install.sh | sh</code>).
+              </p>
               <div style={{ maxWidth: '640px', marginBottom: '2rem' }}>
                 {renderCodeBlock({
                   id: 'install-pip',
                   label: 'Terminal',
-                  code: `pip install policyengine-taxsim`,
+                  code: `uv pip install policyengine-taxsim`,
                 })}
               </div>
 

--- a/cps-dashboard/src/components/LandingPage.jsx
+++ b/cps-dashboard/src/components/LandingPage.jsx
@@ -89,10 +89,13 @@ const LandingPage = ({ onNavigateToDashboard, onNavigateToDocumentation }) => {
       <section className="landing-section">
         <div className="landing-section-inner">
           <h2 className="landing-section-title">Installation</h2>
+          <p style={{ color: 'var(--dark-gray)', marginBottom: '12px', fontSize: '14px' }}>
+            Requires <a href="https://docs.astral.sh/uv/getting-started/installation/" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue-primary)' }}>uv</a> (install with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>curl -LsSf https://astral.sh/uv/install.sh | sh</code>).
+          </p>
           <div className="landing-get-started-code" style={{ maxWidth: '640px', margin: '0 auto' }}>
             <CodeBlock
               label="Terminal"
-              code="pip install policyengine-taxsim"
+              code="uv pip install policyengine-taxsim"
               language="cli"
             />
           </div>

--- a/cps-dashboard/src/components/__tests__/Documentation.test.jsx
+++ b/cps-dashboard/src/components/__tests__/Documentation.test.jsx
@@ -28,7 +28,7 @@ describe('Documentation', () => {
     const blurbs = document.querySelectorAll('.doc-intro-blurb');
     const introBlurb = blurbs[0];
     expect(introBlurb.textContent).toContain('drop-in replacement');
-    expect(introBlurb.textContent).toContain('pip install policyengine-taxsim');
+    expect(introBlurb.textContent).toContain('uv pip install policyengine-taxsim');
   });
 
   it('has all three section tabs', () => {
@@ -41,7 +41,7 @@ describe('Documentation', () => {
   it('shows separate installation and usage sections', () => {
     const { container } = render(<Documentation />);
     // Installation heading
-    expect(container.innerHTML).toContain('pip install policyengine-taxsim');
+    expect(container.innerHTML).toContain('uv pip install policyengine-taxsim');
     // Usage heading with language tabs
     expect(container.innerHTML).toContain('Same input format, same output variables');
   });


### PR DESCRIPTION
## Summary
- Changes all `pip install` references to `uv pip install` on the landing page and documentation
- Adds a note with link to install uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
- Updates test assertions to match

Users were hitting `zsh: command not found: policyengine-taxsim` after `pip install` due to PATH issues. `uv` handles virtual environments and PATH reliably.

## Test plan
- [x] All 8 Documentation tests pass
- [x] Verified fresh install works: `uv venv && uv pip install policyengine-taxsim && policyengine-taxsim --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)