### PR TITLE
Use uv tool install for global PATH access

### DIFF
--- a/cps-dashboard/src/components/Documentation.jsx
+++ b/cps-dashboard/src/components/Documentation.jsx
@@ -409,7 +409,7 @@ policyengine_versions()
             <div className="doc-intro-blurb">
               The PolicyEngine TAXSIM Emulator supports <strong>all input and output variables</strong> provided
               by TAXSIM35. It's a <strong>drop-in replacement</strong> — install
-              with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>uv pip install policyengine-taxsim</code> and
+              with <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>uv tool install policyengine-taxsim</code> and
               swap <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>taxsim35</code> for <code style={{ background: 'var(--blue-98)', padding: '2px 6px', borderRadius: '4px', fontSize: '13px' }}>policyengine-taxsim</code>.
               Like TAXSIM35, this emulator <strong>runs entirely on your machine</strong>.
               Use the same CSV format you already know: provide household demographics,
@@ -454,7 +454,7 @@ policyengine_versions()
                 {renderCodeBlock({
                   id: 'install-pip',
                   label: 'Terminal',
-                  code: `uv pip install policyengine-taxsim`,
+                  code: `uv tool install policyengine-taxsim`,
                 })}
               </div>
 

--- a/cps-dashboard/src/components/LandingPage.jsx
+++ b/cps-dashboard/src/components/LandingPage.jsx
@@ -95,7 +95,7 @@ const LandingPage = ({ onNavigateToDashboard, onNavigateToDocumentation }) => {
           <div className="landing-get-started-code" style={{ maxWidth: '640px', margin: '0 auto' }}>
             <CodeBlock
               label="Terminal"
-              code="uv pip install policyengine-taxsim"
+              code="uv tool install policyengine-taxsim"
               language="cli"
             />
           </div>

--- a/cps-dashboard/src/components/__tests__/Documentation.test.jsx
+++ b/cps-dashboard/src/components/__tests__/Documentation.test.jsx
@@ -28,7 +28,7 @@ describe('Documentation', () => {
     const blurbs = document.querySelectorAll('.doc-intro-blurb');
     const introBlurb = blurbs[0];
     expect(introBlurb.textContent).toContain('drop-in replacement');
-    expect(introBlurb.textContent).toContain('uv pip install policyengine-taxsim');
+    expect(introBlurb.textContent).toContain('uv tool install policyengine-taxsim');
   });
 
   it('has all three section tabs', () => {
@@ -41,7 +41,7 @@ describe('Documentation', () => {
   it('shows separate installation and usage sections', () => {
     const { container } = render(<Documentation />);
     // Installation heading
-    expect(container.innerHTML).toContain('uv pip install policyengine-taxsim');
+    expect(container.innerHTML).toContain('uv tool install policyengine-taxsim');
     // Usage heading with language tabs
     expect(container.innerHTML).toContain('Same input format, same output variables');
   });


### PR DESCRIPTION
## Summary
- Changes `uv pip install` to `uv tool install` in landing page and docs
- `uv tool install` puts the CLI on PATH globally without needing venv activation
- Works better for Stata and other non-Python workflows

## Test plan
- [x] All 8 Documentation tests pass
- [x] Verified on fresh Docker image: `uv tool install` puts binary at `~/.local/bin/`
