### PR TITLE
Replace PAT with GitHub App token and fix CI

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dashboard/build
+          path: ./dashboard/out
 
   deploy:
     environment:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ jobs:
     if: |
       (github.repository == 'PolicyEngine/policyengine-taxsim')
       && (github.event.head_commit.message == 'Update package version')
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -28,7 +30,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI }}
-          skip-existing: true

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -14,10 +14,17 @@ jobs:
     if: |
       (!(github.event.head_commit.message == 'Update package version'))
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Python
@@ -44,4 +51,8 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: "."
+          committer_name: Github Actions[bot]
+          author_name: Github Actions[bot]
           message: Update package version
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false


### PR DESCRIPTION
## Summary

The `POLICYENGINE_GITHUB` PAT was revoked for security reasons, breaking versioning and publish workflows on main. This PR replaces it with the org's GitHub App (matching the pattern used in policyengine-us) and fixes the pages deploy while we're at it.

**versioning.yaml**: Uses `actions/create-github-app-token@v1` with `APP_ID`/`APP_PRIVATE_KEY` org secrets instead of the PAT. The app token is passed to both checkout and the add-and-commit step so the version bump commit triggers downstream workflows (publish).

**publish.yaml**: Switches from `secrets.PYPI` API token to PyPI OIDC trusted publisher — no secrets needed, PyPI verifies the GitHub Actions workflow identity directly. Requires a one-time trusted publisher setup on PyPI (see below).

**deploy-pages.yml**: Fixes artifact path from `./dashboard/build` to `./dashboard/out` — the dashboard is a Next.js app with `output: 'export'`, which outputs to `out/`.

## Prerequisites

1. **APP_ID / APP_PRIVATE_KEY** org secrets must be accessible to this repo (they should already be if set to "all repositories")
2. **PyPI trusted publisher** must be configured at https://pypi.org/manage/project/policyengine-taxsim/settings/publishing/ — add a GitHub publisher with owner `PolicyEngine`, repo `policyengine-taxsim`, workflow `publish.yaml`, environment blank
3. The GitHub App needs permission to bypass branch protection on main (per Ziming's findings) — an admin needs to add the app to the bypass list in repo branch protection settings

## Test plan

- [ ] Verify APP_ID / APP_PRIVATE_KEY secrets are accessible to this repo
- [ ] Configure PyPI trusted publisher for this repo
- [ ] Merge and confirm versioning workflow succeeds on next changelog.d push
- [ ] Confirm publish workflow succeeds after version bump
- [ ] Confirm pages deploy succeeds