### PR TITLE
Fix versioning auth and deploy-pages artifact path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dashboard/build
+          path: ./dashboard/out
 
   deploy:
     environment:

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -14,10 +14,17 @@ jobs:
     if: |
       (!(github.event.head_commit.message == 'Update package version'))
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Python


### PR DESCRIPTION
Fixes #775

## Summary
- **`versioning.yaml`**: Replace expired `POLICYENGINE_GITHUB` PAT with GitHub App token via `actions/create-github-app-token@v2` (using `APP_ID` + `APP_PRIVATE_KEY` secrets), consistent with other PolicyEngine repos
- **`deploy-pages.yml`**: Correct upload artifact path from `./dashboard/build` to `./dashboard/out` (Next.js `output: 'export'` writes to `out/`)

## Test plan
- [ ] Verify `APP_ID` and `APP_PRIVATE_KEY` secrets are available to this repo
- [ ] Merge a changelog fragment to trigger versioning workflow and confirm it passes
- [ ] Trigger deploy-pages workflow and confirm the artifact uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)