### PR TITLE
Add statefip (FIPS code) input support

### DIFF
--- a/changelog.d/add-statefip-support.added.md
+++ b/changelog.d/add-statefip-support.added.md
@@ -1,0 +1,1 @@
+Add statefip (FIPS code) input support, matching TAXSIM-35 behavior.

--- a/dashboard/src/components/CsvRunner.jsx
+++ b/dashboard/src/components/CsvRunner.jsx
@@ -40,7 +40,7 @@ const SAMPLE_DATASETS = [
 const fmt = (n) => Number(n).toLocaleString();
 
 const KNOWN_COLUMNS = new Set([
-  'taxsimid', 'year', 'state', 'mstat', 'page', 'sage',
+  'taxsimid', 'year', 'state', 'statefip', 'mstat', 'page', 'sage',
   'dependent_exemption', 'depx', 'pwages', 'swages',
   'psemp', 'ssemp', 'dividends', 'intrec', 'stcg', 'ltcg',
   'otherprop', 'nonprop', 'pensions', 'gssi',

--- a/policyengine_taxsim/api.py
+++ b/policyengine_taxsim/api.py
@@ -49,6 +49,7 @@ KNOWN_COLUMNS = {
     "taxsimid",
     "year",
     "state",
+    "statefip",
     "mstat",
     "page",
     "sage",

--- a/policyengine_taxsim/core/utils.py
+++ b/policyengine_taxsim/core/utils.py
@@ -284,3 +284,6 @@ SOI_TO_FIPS_MAP = {
     50: 55,  # Wisconsin
     51: 56,  # Wyoming
 }
+
+# Reverse mapping: FIPS → SOI (for statefip input support)
+FIPS_TO_SOI_MAP = {fips: soi for soi, fips in SOI_TO_FIPS_MAP.items()}

--- a/policyengine_taxsim/runners/base_runner.py
+++ b/policyengine_taxsim/runners/base_runner.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 try:
     from ..core.io import write_output
+    from ..core.utils import FIPS_TO_SOI_MAP
 except ImportError:
     from policyengine_taxsim.core.io import write_output
+    from policyengine_taxsim.core.utils import FIPS_TO_SOI_MAP
 
 
 class BaseTaxRunner(ABC):
@@ -38,6 +40,17 @@ class BaseTaxRunner(ABC):
         # year is required by TAXSIM (1960-2023) and PolicyEngine
         if "year" not in self.input_df.columns:
             raise ValueError("Input data must contain a 'year' column")
+
+        # Convert statefip (FIPS) to state (SOI) per row.
+        # Matches TAXSIM-35 behavior: for each record, if state==0
+        # and statefip is set, convert FIPS→SOI.
+        if "statefip" in self.input_df.columns:
+            if "state" not in self.input_df.columns:
+                self.input_df["state"] = 0
+            fips_vals = self.input_df["statefip"].astype(int)
+            soi_from_fips = fips_vals.map(FIPS_TO_SOI_MAP).fillna(0).astype(int)
+            use_fips = (self.input_df["state"] == 0) & (fips_vals > 0)
+            self.input_df.loc[use_fips, "state"] = soi_from_fips[use_fips]
 
         # Auto-assign taxsimid if not present
         if "taxsimid" not in self.input_df.columns:


### PR DESCRIPTION
## Summary
- Adds `statefip` as a recognized input column (FIPS codes)
- When `statefip` is provided and `state` is 0 or missing, automatically converts FIPS→SOI
- Matches TAXSIM-35 behavior (`x(55)` → `ifip2irs` conversion)
- Prevents users from accidentally passing FIPS codes in the `state` column and getting wrong state results (e.g., FIPS 48=Texas interpreted as SOI 48=Washington)

## Test plan
- [x] All 98 existing tests pass
- [x] Verified FIPS 48 (TX) → SOI 44, FIPS 12 (FL) → SOI 10, FIPS 6 (CA) → SOI 5
- [x] State EITC correctly returns 0 for TX and FL when using statefip

🤖 Generated with [Claude Code](https://claude.com/claude-code)