### PR TITLE
Sum person-level variables to tax-unit level in state output resolver

### DIFF
--- a/changelog.d/fix-person-level-broadcasting.fixed.md
+++ b/changelog.d/fix-person-level-broadcasting.fixed.md
@@ -1,0 +1,1 @@
+Sum person-level state variables to tax-unit level in output resolver, fixing broadcasting errors for joint filers in states like MT and CO.

--- a/policyengine_taxsim/core/state_output_resolver.py
+++ b/policyengine_taxsim/core/state_output_resolver.py
@@ -293,6 +293,14 @@ def _try_calculate_variable(
     array = np.asarray(value, dtype=float)
     if array.ndim == 0:
         return np.full(len(state_codes), float(array), dtype=float)
+
+    expected_len = len(state_codes)
+    if len(array) > expected_len:
+        # Person-level variable: sum to tax-unit level.
+        # Each household is processed with a single tax unit,
+        # so all person values belong to that one unit.
+        return np.array([float(array.sum())])
+
     return array.astype(float, copy=False)
 
 

--- a/tests/test_state_output_adapters.py
+++ b/tests/test_state_output_adapters.py
@@ -480,9 +480,7 @@ class TestTryCalculateVariableAggregation:
 
     def test_scalar_broadcasts_to_state_codes_length(self):
         state_codes = np.array(["CA"])
-        result = _try_calculate_variable(
-            "some_var", state_codes, lambda v: 42.0
-        )
+        result = _try_calculate_variable("some_var", state_codes, lambda v: 42.0)
         assert result is not None
         assert len(result) == 1
         assert result[0] == pytest.approx(42.0)
@@ -492,9 +490,7 @@ class TestTryCalculateVariableAggregation:
         result = _try_calculate_variable(
             "some_var",
             state_codes,
-            lambda v: (_ for _ in ()).throw(
-                ValueError("Variable 'x' does not exist")
-            ),
+            lambda v: (_ for _ in ()).throw(ValueError("Variable 'x' does not exist")),
         )
         assert result is None
 
@@ -616,10 +612,12 @@ def test_co_joint_filer_sctc_with_person_level_credit():
 
     # Expected = co_ctc (TaxUnit, .item()) + co_family_affordability_credit (Person, .sum())
     co_ctc = float(simulation.calculate("co_ctc", period=year).item())
-    co_fac = float(np.asarray(
-        simulation.calculate("co_family_affordability_credit", period=year),
-        dtype=float,
-    ).sum())
+    co_fac = float(
+        np.asarray(
+            simulation.calculate("co_family_affordability_credit", period=year),
+            dtype=float,
+        ).sum()
+    )
     expected = co_ctc + co_fac
 
     text = export_household(taxsim_input, situation, False, False)

--- a/tests/test_state_output_adapters.py
+++ b/tests/test_state_output_adapters.py
@@ -1,10 +1,12 @@
 import re
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from policyengine_taxsim import export_household, generate_household
 from policyengine_taxsim.core.state_output_resolver import (
+    _try_calculate_variable,
     get_state_specific_variable_name,
 )
 from policyengine_taxsim.runners.policyengine_runner import PolicyEngineRunner
@@ -437,3 +439,137 @@ def test_combined_state_credit_outputs_do_not_double_count(
 
     total = sum(float(result[var].iloc[0]) for var in taxsim_vars)
     assert total == pytest.approx(expected_total, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Person-level variable aggregation (issue #814)
+# ---------------------------------------------------------------------------
+
+
+class TestTryCalculateVariableAggregation:
+    """Unit tests for _try_calculate_variable handling of Person-level arrays."""
+
+    def test_tax_unit_level_array_returned_unchanged(self):
+        state_codes = np.array(["MT"])
+        result = _try_calculate_variable(
+            "some_var", state_codes, lambda v: np.array([500.0])
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == pytest.approx(500.0)
+
+    def test_person_level_array_summed_to_tax_unit(self):
+        state_codes = np.array(["MT"])
+        # Simulates a head-only Person variable: [credit, 0, 0]
+        result = _try_calculate_variable(
+            "some_var", state_codes, lambda v: np.array([800.0, 0.0, 0.0])
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == pytest.approx(800.0)
+
+    def test_person_level_per_person_values_summed(self):
+        state_codes = np.array(["CO"])
+        # Simulates a per-person credit: each person gets a different amount
+        result = _try_calculate_variable(
+            "some_var", state_codes, lambda v: np.array([300.0, 200.0, 50.0])
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == pytest.approx(550.0)
+
+    def test_scalar_broadcasts_to_state_codes_length(self):
+        state_codes = np.array(["CA"])
+        result = _try_calculate_variable(
+            "some_var", state_codes, lambda v: 42.0
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == pytest.approx(42.0)
+
+    def test_missing_variable_returns_none(self):
+        state_codes = np.array(["MT"])
+        result = _try_calculate_variable(
+            "some_var",
+            state_codes,
+            lambda v: (_ for _ in ()).throw(
+                ValueError("Variable 'x' does not exist")
+            ),
+        )
+        assert result is None
+
+
+# Joint-filer integration tests for states with Person-level variables.
+# These would crash with a broadcasting ValueError before the fix.
+PERSON_LEVEL_JOINT_CASES = [
+    (
+        "v39",
+        {
+            "year": 2024,
+            "state": 27,  # MT
+            "mstat": 2,
+            "page": 40,
+            "sage": 38,
+            "depx": 1,
+            "age1": 5,
+            "pwages": 30_000.0,
+            "swages": 0.0,
+            "taxsimid": 100,
+            "idtl": 2,
+        },
+        "mt_eitc",
+    ),
+    (
+        "v37",
+        {
+            "year": 2024,
+            "state": 27,  # MT
+            "mstat": 2,
+            "page": 70,
+            "sage": 68,
+            "pwages": 10_000.0,
+            "rentpaid": 6_000.0,
+            "taxsimid": 101,
+            "idtl": 2,
+        },
+        "mt_elderly_homeowner_or_renter_credit",
+    ),
+    (
+        "v39",
+        {
+            "year": 2024,
+            "state": 26,  # MO
+            "mstat": 2,
+            "page": 40,
+            "sage": 38,
+            "depx": 1,
+            "age1": 5,
+            "pwages": 30_000.0,
+            "swages": 0.0,
+            "taxsimid": 102,
+            "idtl": 2,
+        },
+        "mo_wftc",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("taxsim_var", "taxsim_input", "pe_variable"), PERSON_LEVEL_JOINT_CASES
+)
+def test_joint_filer_person_level_variables_do_not_crash(
+    taxsim_var, taxsim_input, pe_variable
+):
+    """Regression test for issue #814: Person-level variables must not cause
+    a broadcasting error for joint filers (multiple persons in one tax unit)."""
+    situation = generate_household(dict(taxsim_input))
+    simulation = Simulation(situation=situation)
+    year = str(taxsim_input["year"])
+
+    # Compute expected by summing the person-level array
+    raw = simulation.calculate(pe_variable, period=year)
+    expected = float(np.asarray(raw, dtype=float).sum())
+
+    result = export_household(taxsim_input, situation, False, False)
+
+    assert float(result[taxsim_var]) == pytest.approx(expected, abs=0.01)

--- a/tests/test_state_output_adapters.py
+++ b/tests/test_state_output_adapters.py
@@ -551,6 +551,23 @@ PERSON_LEVEL_JOINT_CASES = [
         },
         "mo_wftc",
     ),
+    # MO: mo_taxable_income is Person-level (separate filing).
+    # Exercises the summing path through the DIRECT v36 adapter.
+    (
+        "v36",
+        {
+            "year": 2024,
+            "state": 26,  # MO
+            "mstat": 2,
+            "page": 40,
+            "sage": 38,
+            "pwages": 50_000.0,
+            "swages": 30_000.0,
+            "taxsimid": 104,
+            "idtl": 2,
+        },
+        "mo_taxable_income",
+    ),
 ]
 
 
@@ -573,3 +590,40 @@ def test_joint_filer_person_level_variables_do_not_crash(
     result = export_household(taxsim_input, situation, False, False)
 
     assert float(result[taxsim_var]) == pytest.approx(expected, abs=0.01)
+
+
+def test_co_joint_filer_sctc_with_person_level_credit():
+    """CO sctc sums co_ctc (TaxUnit) + co_family_affordability_credit (Person).
+    The Person-level credit is per-child and must be summed to tax-unit level.
+    sctc is only available in idtl=5 (text output)."""
+    taxsim_input = {
+        "year": 2024,
+        "state": 6,  # CO
+        "mstat": 2,
+        "page": 35,
+        "sage": 33,
+        "depx": 2,
+        "age1": 3,
+        "age2": 7,
+        "pwages": 40_000.0,
+        "swages": 20_000.0,
+        "taxsimid": 105,
+        "idtl": 5,
+    }
+    situation = generate_household(dict(taxsim_input))
+    simulation = Simulation(situation=situation)
+    year = str(taxsim_input["year"])
+
+    # Expected = co_ctc (TaxUnit, .item()) + co_family_affordability_credit (Person, .sum())
+    co_ctc = float(simulation.calculate("co_ctc", period=year).item())
+    co_fac = float(np.asarray(
+        simulation.calculate("co_family_affordability_credit", period=year),
+        dtype=float,
+    ).sum())
+    expected = co_ctc + co_fac
+
+    text = export_household(taxsim_input, situation, False, False)
+
+    assert isinstance(text, str), "idtl=5 should return text output"
+    actual = _extract_text_value(text, "Child Tax Credit")
+    assert actual == pytest.approx(round(expected, 1))


### PR DESCRIPTION
## Summary

- Fixes broadcasting `ValueError` for joint/family filers in states with Person-level credit variables (MT, CO)
- When a PE variable returns a Person-level array (e.g., 3 values for a 3-person household), sums it to a single tax-unit value instead of crashing
- Adds unit tests for the aggregation logic and integration tests for MT/MO joint filers

Closes #814

## Affected variables

| Variable | State | Output | Entity |
|----------|-------|--------|--------|
| `mt_eitc` | MT | v39 | Person (head-only) |
| `mt_elderly_homeowner_or_renter_credit` | MT | v37 | Person (head-only) |
| `co_family_affordability_credit` | CO | sctc | Person (per-person) |

## Test plan

- [x] 5 unit tests for `_try_calculate_variable` aggregation
- [x] 3 integration tests for MT/MO joint filers through `export_household`
- [x] All 106 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)