### PR TITLE
Map pprofinc/sprofinc to sstb_self_employment_income

### DIFF
--- a/changelog.d/map-sstb-self-employment-income.added.md
+++ b/changelog.d/map-sstb-self-employment-income.added.md
@@ -1,0 +1,1 @@
+Map TAXSIM pprofinc/sprofinc inputs to PolicyEngine sstb_self_employment_income for per-category SSTB QBID computation.

--- a/dashboard/scripts/extract-config.cjs
+++ b/dashboard/scripts/extract-config.cjs
@@ -132,7 +132,7 @@ function extractTaxsimToPolicyEngineMappings(config) {
         }
 
         // Mark certain variables as not available in PolicyEngine
-        const notAvailableVars = ['otherprop', 'nonprop', 'transfers', 'otheritem', 'pprofinc'];
+        const notAvailableVars = ['otherprop', 'nonprop', 'transfers', 'otheritem'];
         if (notAvailableVars.includes(taxsimVar) && policyengineVar === 'Not mapped') {
           policyengineVar = 'na_pe';
           implemented = false;

--- a/dashboard/src/components/CsvRunner.jsx
+++ b/dashboard/src/components/CsvRunner.jsx
@@ -46,7 +46,7 @@ const KNOWN_COLUMNS = new Set([
   'otherprop', 'nonprop', 'pensions', 'gssi',
   'pui', 'sui', 'transfers', 'rentpaid', 'proptax',
   'otheritem', 'childcare', 'mortgage', 'scorp',
-  'pbusinc', 'pprofinc', 'idtl',
+  'pbusinc', 'pprofinc', 'sprofinc', 'idtl',
   // Dependent ages (TAXSIM-35 format)
   'age1', 'age2', 'age3', 'age4', 'age5', 'age6',
   'age7', 'age8', 'age9', 'age10', 'age11',

--- a/dashboard/src/constants/index.js
+++ b/dashboard/src/constants/index.js
@@ -169,7 +169,7 @@ export const INPUT_FIELDS = [
 export const INPUT_VARIABLE_CATEGORIES = {
   basicInputs: ['taxsimid', 'year', 'state', 'mstat', 'page', 'sage', 'dependent_exemption', 'depx'],
   incomeInputs: ['pwages', 'swages', 'psemp', 'ssemp', 'dividends', 'intrec', 'stcg', 'ltcg', 'pensions', 'gssi', 'pui', 'sui'],
-  businessIncomeInputs: ['scorp', 'pbusinc', 'pprofinc'],
+  businessIncomeInputs: ['scorp', 'pbusinc', 'pprofinc', 'sprofinc'],
   expenseInputs: ['rentpaid', 'proptax', 'childcare', 'mortgage', 'otherprop', 'nonprop', 'transfers', 'otheritem']
 };
 

--- a/policyengine_taxsim/api.py
+++ b/policyengine_taxsim/api.py
@@ -77,6 +77,7 @@ KNOWN_COLUMNS = {
     "scorp",
     "pbusinc",
     "pprofinc",
+    "sprofinc",
     "idtl",
     # Dependent ages (TAXSIM-35 format)
     "age1",

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -822,6 +822,9 @@ taxsim_to_policyengine:
           - scorp
       - qualified_business_income:
           - pbusinc
+      - sstb_self_employment_income:
+          - pprofinc
+          - sprofinc
       - rental_income:
       - w2_wages_from_qualified_business:
       - business_is_sstb:
@@ -902,4 +905,7 @@ taxsim_input_definition:
   - pbusinc:
       name: "27. Primary and secondary Taxpayer's active QBI"
   - pprofinc:
-      name: "28. Primary and secondary taxpayer's Specialized Service Trade or Business service"
+      name: "28. Primary taxpayer's SSTB self-employment income"
+      pair: sprofinc
+  - sprofinc:
+      name: "28b. Spouse's SSTB self-employment income"

--- a/policyengine_taxsim/core/input_mapper.py
+++ b/policyengine_taxsim/core/input_mapper.py
@@ -76,6 +76,14 @@ def add_additional_units(state, year, situation, taxsim_vars):
                         str(year): taxsim_vars.get("ssemp", 0)
                     }
 
+            elif field == "sstb_self_employment_income":
+                if "pprofinc" in taxsim_vars:
+                    people_unit["you"][field] = {str(year): taxsim_vars.get("pprofinc", 0)}
+                if "your partner" in people_unit and "sprofinc" in taxsim_vars:
+                    people_unit["your partner"][field] = {
+                        str(year): taxsim_vars.get("sprofinc", 0)
+                    }
+
             elif field == "unemployment_compensation":
                 if "pui" in taxsim_vars:
                     people_unit["you"][field] = {str(year): taxsim_vars.get("pui", 0)}

--- a/policyengine_taxsim/core/input_mapper.py
+++ b/policyengine_taxsim/core/input_mapper.py
@@ -78,7 +78,9 @@ def add_additional_units(state, year, situation, taxsim_vars):
 
             elif field == "sstb_self_employment_income":
                 if "pprofinc" in taxsim_vars:
-                    people_unit["you"][field] = {str(year): taxsim_vars.get("pprofinc", 0)}
+                    people_unit["you"][field] = {
+                        str(year): taxsim_vars.get("pprofinc", 0)
+                    }
                 if "your partner" in people_unit and "sprofinc" in taxsim_vars:
                     people_unit["your partner"][field] = {
                         str(year): taxsim_vars.get("sprofinc", 0)
@@ -193,9 +195,11 @@ def form_household_situation(year, state, taxsim_vars):
         dep_name = f"your {get_ordinal(i)} dependent"
         people[dep_name] = {
             "age": {
-                str(year): int(taxsim_vars.get(f"age{i}", 10))
-                if taxsim_vars.get(f"age{i}") is not None
-                else 10
+                str(year): (
+                    int(taxsim_vars.get(f"age{i}", 10))
+                    if taxsim_vars.get(f"age{i}") is not None
+                    else 10
+                )
             },
             "employment_income": {str(year): 0},
             "is_tax_unit_dependent": {str(year): True},

--- a/policyengine_taxsim/core/io.py
+++ b/policyengine_taxsim/core/io.py
@@ -9,7 +9,6 @@ import pandas as pd
 from pathlib import Path
 from typing import Union
 
-
 STATA_EXTENSIONS = {".dta"}
 
 

--- a/policyengine_taxsim/core/marginal_rates.py
+++ b/policyengine_taxsim/core/marginal_rates.py
@@ -15,7 +15,6 @@ a single tax bracket for most filers.
 import copy
 from policyengine_us import Simulation
 
-
 DELTA = 100.0  # $100: large enough for float32 precision, small for bracket safety
 
 

--- a/policyengine_taxsim/core/state_output_resolver.py
+++ b/policyengine_taxsim/core/state_output_resolver.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 
-
 OUTPUT_ADAPTER_BASE_VARIABLES = {
     "taxsim_v32_state_agi": "state_agi",
     "taxsim_v38_cdcc": "state_cdcc",


### PR DESCRIPTION
## Summary
- Maps TAXSIM `pprofinc`/`sprofinc` inputs to PE `sstb_self_employment_income` for per-category SSTB QBID computation under IRC §199A(d)(2)-(3)
- Adds primary/spouse handling in input mapper (matching `psemp`/`ssemp` pattern)
- Updates dashboard to recognize `sprofinc` and mark `pprofinc` as mapped

## Blocked on
- PolicyEngine/policyengine-us#7939 — adds `sstb_self_employment_income` variable and SSTB QBID logic

## Test plan
- [x] All existing tests pass
- [ ] Verify end-to-end with policyengine-us SSTB changes merged
- [ ] Run comparison against TAXSIM for records with pprofinc values

🤖 Generated with [Claude Code](https://claude.com/claude-code)