### PR TITLE
Unify sctc to use pe-us state_ctc aggregate

### DIFF
--- a/changelog.d/unify-sctc-state-ctc.changed.md
+++ b/changelog.d/unify-sctc-state-ctc.changed.md
@@ -1,0 +1,1 @@
+Unify `sctc` output adapter to use pe-us `state_ctc` aggregate (gov.states.household.state_ctcs) instead of duplicated per-state mapping. OK/MN component-split overrides are preserved in the resolver.

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -678,29 +678,10 @@ policyengine_to_taxsim:
     full_text_group: "State Tax Calculation"
     group_column: 1
   sctc:
+    # Value comes from pe-us taxsim_state_ctc (aggregates
+    # gov.states.household.state_ctcs). OK and MN require component splits
+    # handled via OUTPUT_ADAPTER_OVERRIDES in state_output_resolver.py.
     variable: taxsim_sctc
-    state_variables:
-      AZ: az_dependent_tax_credit
-      CA: ca_yctc
-      CO:
-        - co_ctc
-        - co_family_affordability_credit
-      CT: ct_child_tax_rebate
-      DC: dc_ctc
-      ID: id_ctc
-      IL: il_ctc
-      MA: ma_child_and_family_credit
-      MD: md_ctc
-      MN: adapter:mn_child_tax_credit_component
-      NE: ne_refundable_ctc
-      NJ: nj_ctc
-      NM: nm_ctc
-      NY: ny_ctc
-      OK: adapter:ok_child_tax_credit_component
-      OR: or_ctc
-      RI: ri_child_tax_rebate
-      UT: ut_ctc
-      VT: vt_ctc
     implemented: true
     idtl:
       - full_text: 5

--- a/policyengine_taxsim/core/state_output_resolver.py
+++ b/policyengine_taxsim/core/state_output_resolver.py
@@ -6,10 +6,10 @@ OUTPUT_ADAPTER_BASE_VARIABLES = {
     "taxsim_v32_state_agi": "state_agi",
     "taxsim_v38_cdcc": "state_cdcc",
     "taxsim_v39_eitc": "state_eitc",
+    "taxsim_sctc": "state_ctc",
 }
 DIRECT_STATE_MAPPING_ADAPTERS = {
     "taxsim_staxbc",
-    "taxsim_sctc",
     "taxsim_v36_taxable_income",
     "taxsim_v37_property_tax_credit",
 }


### PR DESCRIPTION
## Summary

Removes the duplicated per-state `state_variables:` dict from `sctc:` in `variable_mappings.yaml`. The `sctc` output field now routes through pe-us's `state_ctc` variable, which aggregates `gov.states.household.state_ctcs` — the same catalog that `state_cdcc` / `state_eitc` already use via the `v38` / `v39` adapters.

## Motivation

The `sctc` mapping was the last holdout using the per-state `state_variables:` lookup instead of the shared pe-us aggregate. That created:

1. **Duplicate logic**: adding/removing a state CTC required touching both pe-us (`state_ctcs.yaml`) and pe-taxsim (`variable_mappings.yaml`).
2. **Drift risk**: the pe-taxsim dict had `CT: ct_child_tax_rebate`, a one-time 2022 rebate, still producing phantom values for 2023+ (surfaced in policyengine-taxsim#849). The pe-us aggregate (once [pe-us#8146](https://github.com/PolicyEngine/policyengine-us/issues/8146) merges) won't have this problem.

After this change, `sctc` behaves consistently with `v38` (CDCC) and `v39` (EITC): single source of truth in pe-us, component-split overrides in the resolver for OK and MN.

## Changes

- `state_output_resolver.py`: `taxsim_sctc` moves from `DIRECT_STATE_MAPPING_ADAPTERS` to `OUTPUT_ADAPTER_BASE_VARIABLES` with base variable `state_ctc`.
- `variable_mappings.yaml`: removes the 20-state `state_variables:` block under `sctc:`.
- OK/MN overrides (`adapter:ok_child_tax_credit_component`, `adapter:mn_child_tax_credit_component`) stay in `OUTPUT_ADAPTER_OVERRIDES["taxsim_sctc"]` — unchanged behavior.

## Test plan

- [x] All 121 existing pe-taxsim tests pass with pe-us local checkout.
- [x] End-to-end smoke test across AZ, CA, CT, DE, IL, MN, NY, OK — values match pre-unification except CT (improves: see [pe-us#8146](https://github.com/PolicyEngine/policyengine-us/issues/8146)).
- [x] Lint clean (black).

## Related

- [policyengine-taxsim#849](https://github.com/PolicyEngine/policyengine-taxsim/issues/849) — CT phantom \$500 discovered bug
- [policyengine-us#8146](https://github.com/PolicyEngine/policyengine-us/issues/8146) — upstream fix removing `ct_child_tax_rebate` from `state_ctcs.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)