### PR TITLE
Fix MT v32 (State AGI) returning $0 in TAXSIM output

### DIFF
--- a/changelog.d/fix-mt-v32-mapping.fixed.md
+++ b/changelog.d/fix-mt-v32-mapping.fixed.md
@@ -1,0 +1,1 @@
+Fix v32 (State AGI) output returning $0 for Montana — route `taxsim_v32_state_agi` to `mt_agi_joint` (the tax-unit-level MT AGI that applies to joint, single, and HoH filers) instead of the default `state_agi` path, which reads the person-level `mt_agi_indiv` (defined only for MFS-on-same-return) and returns 0 for everyone else.

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -378,7 +378,7 @@ policyengine_to_taxsim:
       MN: adjusted_gross_income
       MO: mo_adjusted_gross_income
       MS: ms_agi
-      MT: mt_agi
+      MT: mt_agi_joint
       NC: adjusted_gross_income
       ND: adjusted_gross_income
       NE: ne_agi

--- a/policyengine_taxsim/core/state_output_resolver.py
+++ b/policyengine_taxsim/core/state_output_resolver.py
@@ -14,6 +14,11 @@ DIRECT_STATE_MAPPING_ADAPTERS = {
     "taxsim_v37_property_tax_credit",
 }
 OUTPUT_ADAPTER_OVERRIDES = {
+    # MT: state_agi reads `gov.states.household.state_agis` which lists
+    # `mt_agi_indiv` (Person, defined only for MFS-on-same-return). For all
+    # other MT filing statuses that returns 0; use the tax-unit-level
+    # `mt_agi_joint` instead (PE-US naming, but applies to joint, single, HoH).
+    "taxsim_v32_state_agi": {"MT": ["mt_agi_joint"]},
     "taxsim_v38_cdcc": {"OK": ["adapter:ok_child_care_credit_component"]},
     "taxsim_v39_eitc": {"MN": ["mn_wfc"]},
     "taxsim_sctc": {

--- a/tests/test_state_output_adapters.py
+++ b/tests/test_state_output_adapters.py
@@ -123,6 +123,21 @@ DICT_OUTPUT_CASES = [
         },
         ["mn_wfc"],
     ),
+    (
+        "v32",
+        {
+            "year": 2025,
+            "state": 27,  # MT — defaults `state_agi` to `mt_agi_indiv` (Person,
+            # defined only for MFS-on-same-return) and returns 0 for everyone else.
+            # The override on taxsim_v32_state_agi routes MT to `mt_agi_joint`,
+            # the tax-unit-level MT AGI that applies to joint/single/HoH filers.
+            "pwages": 80_000.0,
+            "taxsimid": 11,
+            "idtl": 2,
+            "mstat": 1,
+        },
+        ["mt_agi_joint"],
+    ),
 ]
 
 TEXT_OUTPUT_CASES = [


### PR DESCRIPTION
## Summary

For Montana filers, the `v32` (State AGI) output of the TAXSIM emulator returned `$0` regardless of filing status, even though MT tax was computed correctly. Root cause: the `taxsim_v32_state_agi` adapter reads PE-US's unified `state_agi` → `taxsim_state_agi` → sums `gov.states.household.state_agis`, which for MT lists `mt_agi_indiv` — a person-level variable `defined_for = "mt_married_filing_separately_on_same_return_eligible"` that returns `0` for joint, single, and HoH filers.

The MT tax computation itself runs off `mt_agi_joint` (tax-unit level) and is unaffected — only the displayed `v32` was wrong, which made TAXSIM output look like PE skipped MT AGI.

## Fix

Add `"taxsim_v32_state_agi": {"MT": ["mt_agi_joint"]}` to `OUTPUT_ADAPTER_OVERRIDES` so MT routes through `mt_agi_joint`, the tax-unit-level MT AGI that applies to all filing statuses except MFS-on-same-return (which is rare in TAXSIM inputs). Also align the per-state fallback in `variable_mappings.yaml` (`mt_agi` → `mt_agi_joint`) for consistency.

## Test plan

- New parametrized cases in `tests/test_state_output_adapters.py`:
  - MT single filer ($80K pwages) — v32 was `$0`, now `$80,000` (federal AGI = MT AGI when no MT-specific subtractions).
  - End-to-end check on issue 862 inputs (MT joint, $129K pwages + $20K spouse, $30K proptax + $20K mortgage): v32 was `$0`, now `$150,481.69`.
- Full `tests/test_state_output_adapters.py` and `tests/test_mappers.py` pass (47 tests).

## Reported in

[policyengine-taxsim#862](https://github.com/PolicyEngine/policyengine-taxsim/issues/862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)