### PR TITLE
Strip whitespace from CSV column headers

### DIFF
--- a/changelog.d/strip-csv-whitespace.fixed.md
+++ b/changelog.d/strip-csv-whitespace.fixed.md
@@ -1,0 +1,1 @@
+Strip whitespace from CSV column headers on input so columns with leading/trailing spaces (e.g. ` ltcg ,`) are recognized rather than silently dropped, matching what TAXSIM-style users expect.

--- a/policyengine_taxsim/cli.py
+++ b/policyengine_taxsim/cli.py
@@ -112,6 +112,7 @@ def cli(ctx, logs, disable_salt, sample):
 
     try:
         df = pd.read_csv(sys.stdin)
+        df.columns = [c.strip() for c in df.columns]
 
         # Apply sampling if requested
         if sample and sample < len(df):

--- a/policyengine_taxsim/core/io.py
+++ b/policyengine_taxsim/core/io.py
@@ -20,7 +20,9 @@ def read_input(path: Union[str, Path]) -> pd.DataFrame:
     """Read a TAXSIM-format input file (CSV or Stata)."""
     if _is_stata(path):
         return pd.read_stata(path)
-    return pd.read_csv(path)
+    df = pd.read_csv(path)
+    df.columns = [c.strip() for c in df.columns]
+    return df
 
 
 def write_output(

--- a/tests/test_stata_io.py
+++ b/tests/test_stata_io.py
@@ -2,7 +2,6 @@
 
 import pandas as pd
 import pytest
-from pathlib import Path
 
 from policyengine_taxsim.core.io import read_input, write_output
 
@@ -51,8 +50,7 @@ class TestReadInput:
         # silently drop the data. Strip whitespace from headers on read.
         csv_path = tmp_path / "spaced.csv"
         csv_path.write_text(
-            "taxsimid,year,state,mstat,pwages, ltcg ,idtl\n"
-            "1,2025,5,1,50000,10000,2\n"
+            "taxsimid,year,state,mstat,pwages, ltcg ,idtl\n1,2025,5,1,50000,10000,2\n"
         )
 
         result = read_input(csv_path)

--- a/tests/test_stata_io.py
+++ b/tests/test_stata_io.py
@@ -45,6 +45,21 @@ class TestReadInput:
         result = read_input(txt_path)
         assert len(result) == 2
 
+    def test_read_csv_strips_whitespace_from_headers(self, tmp_path):
+        # taxsim #418: spaces before/after column names (e.g. " ltcg") were
+        # making pandas treat the space-prefixed column as unrecognized and
+        # silently drop the data. Strip whitespace from headers on read.
+        csv_path = tmp_path / "spaced.csv"
+        csv_path.write_text(
+            "taxsimid,year,state,mstat,pwages, ltcg ,idtl\n"
+            "1,2025,5,1,50000,10000,2\n"
+        )
+
+        result = read_input(csv_path)
+        assert "ltcg" in result.columns
+        assert " ltcg " not in result.columns
+        assert result["ltcg"].iloc[0] == 10_000
+
 
 class TestWriteOutput:
     def test_write_csv(self, tmp_path, sample_df):


### PR DESCRIPTION
## Summary

When a TAXSIM-format input CSV has whitespace around a column name (e.g. ` ltcg ,`), pandas treats the padded name as a distinct column. Downstream code looks up `ltcg` and finds nothing, so the value is silently dropped from federal AGI / state calculations.

Strip whitespace from headers in both the stdin/stdout CLI path (`policyengine_taxsim/cli.py`) and the file-based reader (`policyengine_taxsim/core/io.py`) so users get the expected behavior.

## Reproducer

```bash
echo 'taxsimid,year,state,mstat,pwages, ltcg,idtl
1,2025,5,1,50000,10000,2' | policyengine-taxsim
```

Before: `v10 = 50,000` (ltcg silently ignored).
After: `v10 = 60,000` (ltcg counted).

## Test plan

- New test `test_read_csv_strips_whitespace_from_headers` in `tests/test_stata_io.py` covering both leading and trailing whitespace.
- `pytest tests/test_stata_io.py` (7 tests) green.

## Reported in

[policyengine-taxsim#418](https://github.com/PolicyEngine/policyengine-taxsim/issues/418)

🤖 Generated with [Claude Code](https://claude.com/claude-code)