### PR TITLE
Silence Hugging Face Hub anonymous-request warning

### DIFF
--- a/changelog.d/silence-hf-warning.changed.md
+++ b/changelog.d/silence-hf-warning.changed.md
@@ -1,0 +1,1 @@
+Suppress benign Hugging Face Hub anonymous-request warnings during CLI runs.

--- a/policyengine_taxsim/cli.py
+++ b/policyengine_taxsim/cli.py
@@ -1,7 +1,14 @@
+import logging
+
 import click
 import pandas as pd
 from pathlib import Path
 from io import StringIO
+
+# Suppress benign Hugging Face Hub warnings (e.g., "unauthenticated requests"
+# rate-limit notices) — downloads still succeed under the anonymous limit,
+# and the message confuses TAXSIM users who don't have an HF account.
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
 
 try:
     from .runners.policyengine_runner import PolicyEngineRunner


### PR DESCRIPTION
## Summary
- Raise the `huggingface_hub` logger to `ERROR` at CLI entry so the server-side `X-HF-Warning` rate-limit notice (anonymous downloads still succeed) doesn't surface to TAXSIM users
- Real HTTP failures still raise exceptions; only informational warnings are hidden

## Context
Closes #918. The warning text "You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads" is emitted by `huggingface_hub.utils._http._warn_on_warning_headers` when the server returns `X-HF-Warning` headers (which it always does for anonymous requests). PE-US downloads its calibrated microdata from HF on first use; TAXSIM users typically don't have HF accounts, and the warning reads like an error.

## Test plan
- [x] Verified locally that `huggingface_hub.utils._http` warning is suppressed but ERROR-level messages still surface
- [x] `tests/test_cli_entry_point.py` + `tests/test_stitched_runner.py` pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)