### PR TITLE
Route CLI status messages to stderr (#858)

### DIFF
--- a/changelog.d/cli-status-to-stderr.fixed.md
+++ b/changelog.d/cli-status-to-stderr.fixed.md
@@ -1,0 +1,1 @@
+Route CLI status messages (dataset setup, microsim progress, "Results saved") to stderr so they don't contaminate piped CSV output on stdout.

--- a/policyengine_taxsim/cli.py
+++ b/policyengine_taxsim/cli.py
@@ -197,13 +197,13 @@ def policyengine(input_file, output, logs, disable_salt, assume_w2_wages, sample
 
         # Generate YAML files if requested
         if logs:
-            click.echo("Generating PolicyEngine YAML test files...")
+            click.echo("Generating PolicyEngine YAML test files...", err=True)
             _generate_yaml_files(df_with_ids, results_df)
-            click.echo(f"Generated {len(df_with_ids)} YAML test files")
+            click.echo(f"Generated {len(df_with_ids)} YAML test files", err=True)
 
         # Save results to output file
         write_output(results_df, output)
-        click.echo(f"Results saved to {output}")
+        click.echo(f"Results saved to {output}", err=True)
 
     except Exception as e:
         click.echo(f"Error processing input: {str(e)}", err=True)

--- a/policyengine_taxsim/runners/base_runner.py
+++ b/policyengine_taxsim/runners/base_runner.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 from abc import ABC, abstractmethod
 from typing import Optional, Union
@@ -103,14 +105,14 @@ class BaseTaxRunner(ABC):
         """
         if results_df is None:
             if self.results is None:
-                print("Running calculations to generate results...")
+                print("Running calculations to generate results...", file=sys.stderr)
                 results_df = self.run()
             else:
                 results_df = self.results
 
         output_path = Path(output_path)
         write_output(results_df, output_path)
-        print(f"Results saved to: {output_path}")
+        print(f"Results saved to: {output_path}", file=sys.stderr)
 
     def get_record_count(self) -> int:
         """Get number of records in input data"""

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import numpy as np
 import tempfile
@@ -733,7 +735,7 @@ class TaxsimMicrosimDataset(Dataset):
         self.input_df = self._ensure_required_columns(self.input_df)
 
         # Set defaults and convert TAXSIM32 format (vectorized)
-        print("Setting defaults for TAXSIM records...")
+        print("Setting defaults for TAXSIM records...", file=sys.stderr)
         self.input_df = self._apply_defaults_vectorized(self.input_df)
 
         # Extract years (assuming all records might have different years)
@@ -749,7 +751,7 @@ class TaxsimMicrosimDataset(Dataset):
         data = self._initialize_dataset_structure()
 
         # Process each year separately
-        print("Processing years for dataset generation...")
+        print("Processing years for dataset generation...", file=sys.stderr)
         for year in tqdm(unique_years, desc="Dataset generation by year"):
             year_mask = self.input_df["year"] == year
             year_data = self.input_df[year_mask].copy()
@@ -1005,7 +1007,8 @@ class PolicyEngineRunner(BaseTaxRunner):
         """
         if show_progress:
             print(
-                f"Running PolicyEngine Microsimulation on {len(self.input_df)} records"
+                f"Running PolicyEngine Microsimulation on {len(self.input_df)} records",
+                file=sys.stderr,
             )
 
         # Ensure years are integers to handle decimal values like 2021.0
@@ -1043,7 +1046,7 @@ class PolicyEngineRunner(BaseTaxRunner):
         results_df = pd.concat(frames, ignore_index=True)
 
         if show_progress:
-            print("PolicyEngine Microsimulation completed")
+            print("PolicyEngine Microsimulation completed", file=sys.stderr)
 
         return results_df
 


### PR DESCRIPTION
## Summary
- Send dataset setup notices, microsim run/complete messages, and "Results saved to ..." to **stderr** instead of stdout
- Keeps piped CSV output clean in `policyengine-taxsim < input > output` and Daniel's `-o /dev/stdout` workflow

## Context
Closes #858. Daniel reported that running `-o /dev/stdout` produced output like:

```
taxsimid,year,state,fiitax,siitax,fica,tfica...
111773,2025,21,132057.58,29687.54,0.0...
PolicyEngine Microsimulation completed       ← leaks to stdout
Results saved to /dev/stdout                 ← leaks to stdout
```

The tqdm progress bars were already on stderr; this PR moves the remaining `print()` / `click.echo()` status lines to match (`file=sys.stderr` for `print`, `err=True` for `click.echo`).

## Test plan
- [x] Verified `policyengine-taxsim < input.csv > output.csv` writes only CSV to stdout
- [x] Verified `policyengine-taxsim policyengine input.csv -o output.csv` keeps status on stderr
- [x] Verified `2>/dev/null` produces fully silent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)