### PR TITLE
Map otherprop input to miscellaneous_income

### DIFF
--- a/changelog.d/map-otherprop.fixed.md
+++ b/changelog.d/map-otherprop.fixed.md
@@ -1,0 +1,1 @@
+Map the TAXSIM `otherprop` input to PE-US `miscellaneous_income` so "Other Property" income flows into federal AGI (previously silently dropped).

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -807,6 +807,8 @@ taxsim_to_policyengine:
           - pprofinc
           - sprofinc
       - rental_income:
+      - miscellaneous_income:
+          - otherprop
       - w2_wages_from_qualified_business:
       - business_is_sstb:
       - business_is_qualified:


### PR DESCRIPTION
## Summary
- Wire `otherprop` (TAXSIM-35 input #15, "Other Property") to PE-US `miscellaneous_income` in `variable_mappings.yaml`
- Previously unmapped — PE-taxsim silently dropped the value before Microsim, while TAXSIM-35 binary includes it in AGI

## Why this matters
On the 3K eCPS 2025 sample, **92% of records with `otherprop ≠ 0` mismatched federally**. The eCPS converter packs `rental_income` into `otherprop` for TAXSIM-format output; without an inbound mapping, that income vanishes when the comparator runs the round-trip through PE-taxsim.

## Why `miscellaneous_income` (not `rental_income`)
The natural symmetric mapping is `rental_income`, but PE-US auto-applies QBID to `rental_income` (20% deduction = \$16,850 on a \$100K case), where TAXSIM-35 only triggers QBID via the explicit `pbusinc` input. `miscellaneous_income` adds to AGI through `irs_gross_income` without auto-qualifying for QBI.

## Smoke test
otherprop=\$100K, single age 40 → PE matches TAXSIM-35 exactly (\$13,449 fiitax, \$100K v10, \$84,250 v18).

## 3K eCPS 2025 realistic subset (|AGI|<\$500K, no S-Corp)

| Metric | Pre-fix | **Post-fix** |
|---|---|---|
| Federal exact | 86.5% | **89.8%** |
| Federal within \$100 | ~88% | **93.1%** |
| Federal within \$1K | ~96% | **97.9%** |
| State within \$100 | ~91% | **93.3%** |
| State within \$1K | ~95% | **98.3%** |

## Test plan
- [x] 117/117 existing tests pass
- [x] Smoke test reproduces exact TAXSIM-35 match
- [x] 3K eCPS sample re-run confirms improvement