### PR TITLE
Set MN renter credit qualifying_crp for TAXSIM inputs

### DIFF
--- a/changelog.d/mn-renters-credit-crp-default.fixed.md
+++ b/changelog.d/mn-renters-credit-crp-default.fixed.md
@@ -1,0 +1,1 @@
+PolicyEngineRunner now sets `mn_renters_credit_qualifying_crp = True` for MN tax units with `rentpaid > 0`, matching Minn. Stat. § 290.0693 (the CRP is documentation, not a substantive eligibility gate).

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -1011,6 +1011,34 @@ class PolicyEngineRunner(BaseTaxRunner):
                         ),
                     )
 
+            # MN Renter's Credit: PE-US gates the credit on a Certificate
+            # of Rent Paid (CRP) input variable that defaults to False. Per
+            # Minn. Stat. § 290.0693, the credit is allowed for renters who
+            # paid rent and meet income criteria; subd. 4 places the CRP
+            # issuance obligation on the landlord (not the renter), and
+            # subd. 9 accepts proof "including but not limited to" the CRP.
+            # TAXSIM input never carries CRP info, so we assume any MN
+            # tax unit with rent > 0 has the supporting documentation.
+            if "rentpaid" in chunk_df.columns and "state" in chunk_df.columns:
+                mn_mask = (chunk_df["state"] == 24) & (chunk_df["rentpaid"] > 0)
+                if mn_mask.any():
+                    years = sorted(set(chunk_df["year"].unique()))
+                    for year in years:
+                        year_mask = (chunk_df["year"] == year) & mn_mask
+                        if year_mask.any():
+                            # qualifying_crp is on TaxUnit; vector aligns
+                            # with the chunk's tax-unit order, one row per
+                            # tax unit.
+                            sim.set_input(
+                                variable_name="mn_renters_credit_qualifying_crp",
+                                value=mn_mask[chunk_df["year"] == year].values,
+                                period=str(
+                                    int(year)
+                                    if isinstance(year, (float, np.floating))
+                                    else year
+                                ),
+                            )
+
             return self._extract_vectorized_results(sim, chunk_df)
 
         finally:


### PR DESCRIPTION
## Summary

PE-US's `mn_renters_credit_qualifying_crp` defaults to `False`, requiring filers to explicitly affirm they hold a Certificate of Rent Paid. Per **Minn. Stat. § 290.0693**, the credit is allowed for renters meeting rent and income criteria; subd. 4 places the CRP issuance obligation on the landlord, and subd. 9 accepts proof "including but not limited to" the CRP.

TAXSIM input carries no CRP info, so the emulator now assumes any MN tax unit reporting `rentpaid > 0` has the supporting documentation — matching TAXSIM-35's behavior on the same input and the statutory eligibility.

Closes the ~$20K MN state-side gap in eCPS comparisons driven by low-income MN renters being denied the credit when PE-taxsim runs them.

Refs: #939 (confirmed by Dan: "setting mn_renters_credit_qualifying_crp to true seems right ... It would match the code in Taxsim, though.")

## Verification

| Test | Result |
|---|---|
| **#939 record** (MN joint, $71K rent) | PE siitax = **−$2,216** ✓ matches TaxAct M1RENT ($2,240 refund within rounding) |
| **CA + rent (non-MN)** | PE matches TAXSIM ($135) ✓ unaffected |
| **MN no rent** | PE matches TAXSIM ($426) ✓ unaffected |
| **Full pytest suite** | 137/137 pass ✓ |

## Test plan

- [x] Targeted smoke tests on MN+rent / non-MN+rent / MN no-rent
- [x] `pytest tests/` — all 137 tests pass
- [x] Statute verified against Minn. Stat. § 290.0693 subd. 2, 4, and 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)