### PR TITLE
Pass opt1/opt1v through TaxsimRunner to TAXSIM-35

### DIFF
--- a/changelog.d/taxsim-runner-opt1-columns.added.md
+++ b/changelog.d/taxsim-runner-opt1-columns.added.md
@@ -1,0 +1,1 @@
+TaxsimRunner now passes through `opt1` and `opt1v` columns to the TAXSIM-35 binary, enabling callers to toggle TAXSIM behaviors (e.g., `opt1=30, opt1v=1` switches one-time rebate timing to PE's liability-year convention).

--- a/policyengine_taxsim/runners/taxsim_runner.py
+++ b/policyengine_taxsim/runners/taxsim_runner.py
@@ -71,8 +71,21 @@ class TaxsimRunner(BaseTaxRunner):
         "idtl",  # Output control
     ]
 
+    # TAXSIM-35 option columns. Pass-through to the binary so callers can
+    # toggle TAXSIM behaviors (e.g., opt1=30, opt1v=1 switches one-time
+    # rebate timing to the liability-year convention PE uses).
+    # See https://taxsim.nber.org/taxsimtest/options.html
+    OPTION_COLUMNS = [
+        "opt1",  # Option selector (e.g., 27 = rebate timing, 30 = PE-aligned umbrella)
+        "opt1v",  # Option value
+    ]
+
     ALL_COLUMNS = (
-        REQUIRED_COLUMNS + DEPENDENT_AGE_COLUMNS + TAXSIM32_COLUMNS + INCOME_COLUMNS
+        REQUIRED_COLUMNS
+        + DEPENDENT_AGE_COLUMNS
+        + TAXSIM32_COLUMNS
+        + INCOME_COLUMNS
+        + OPTION_COLUMNS
     )
 
     def __init__(self, input_df: pd.DataFrame, taxsim_path: str = None):
@@ -173,6 +186,10 @@ class TaxsimRunner(BaseTaxRunner):
 
             # Add income columns (but exclude TAXSIM32 columns since TAXSIM-35 uses individual ages)
             dynamic_columns.extend(self.INCOME_COLUMNS)
+
+            # Add option columns (opt1, opt1v) so callers can toggle
+            # TAXSIM-35 behaviors via the standard TAXSIM input.
+            dynamic_columns.extend(self.OPTION_COLUMNS)
 
             # Create row data with only needed columns
             row_data = {}


### PR DESCRIPTION
## Summary

TaxsimRunner's column list previously omitted TAXSIM-35's option fields, so any `opt1`/`opt1v` values in input CSVs were silently dropped before invoking the binary. This change adds them to `ALL_COLUMNS` and the dynamic per-record column list emitted to the TAXSIM input file.

The immediate use case is `opt1=30, opt1v=1`, which switches TAXSIM-35 to PE's liability-year convention for one-time state rebates (per [Dan Feenberg's options docs](https://taxsim.nber.org/taxsimtest/options.html)).

## Impact

On the 2K-record eCPS sample, passing `opt1=30` raised state match rate from **78.5% → 84.8%** and closed:

| State | Baseline gap | With opt1=30 | Closed |
|---|---|---|---|
| GA | $14,378 | $3 | **100%** (surplus rebate convention) |
| HI | $13,301 | $1,607 | 88% |
| VA | $7,764 | $524 | 93% (HB 1600 + STA) |
| NJ | $2,133 | $152 | 93% |
| IL | $1,583 | $12 | 99% |
| KY | $1,899 | $883 | 54% |

No PE-side model change — purely a pass-through fix to let the TAXSIM-35 binary respect input options.

## Refs

- #539 — original feature request
- #716 — GA surplus rebate convention discussion (resolved that PE keeps liability-year, opt1=30 lets TAXSIM match)
- #718 — VA HB 1600 same shape

## Test plan

- [x] `pytest tests/` — all 137 tests pass
- [x] Smoke test on 4 GA records: opt1=30 closes the +$250 surplus rebate diff exactly
- [x] eCPS 2K-sample with opt1=30: state match 78.5% → 84.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)