### PR TITLE
Preserve TAXSIM option columns for remote runs

### DIFF
--- a/changelog.d/539.added.md
+++ b/changelog.d/539.added.md
@@ -1,0 +1,1 @@
+Preserve TAXSIM option columns (`opt1`, `opt1v`) for hosted TAXSIM runs.

--- a/policyengine_taxsim/runners/remote_taxsim_runner.py
+++ b/policyengine_taxsim/runners/remote_taxsim_runner.py
@@ -55,7 +55,16 @@ class RemoteTaxsimRunner(BaseTaxRunner):
         "idtl",
     ]
 
-    ALL_COLUMNS = REQUIRED_COLUMNS + DEPENDENT_AGE_COLUMNS + INCOME_COLUMNS
+    # TAXSIM-35 option columns. Pass-through to the hosted service so callers
+    # can set options such as opt1=30, opt1v=1.
+    OPTION_COLUMNS = [
+        "opt1",
+        "opt1v",
+    ]
+
+    ALL_COLUMNS = (
+        REQUIRED_COLUMNS + DEPENDENT_AGE_COLUMNS + INCOME_COLUMNS + OPTION_COLUMNS
+    )
 
     def __init__(self, input_df: pd.DataFrame):
         super().__init__(input_df)
@@ -87,6 +96,7 @@ class RemoteTaxsimRunner(BaseTaxRunner):
         for i in range(max_depx):
             columns.append(f"age{i + 1}")
         columns.extend(self.INCOME_COLUMNS)
+        columns.extend(self.OPTION_COLUMNS)
 
         # Build CSV
         lines = [",".join(columns)]

--- a/tests/test_taxsim_options.py
+++ b/tests/test_taxsim_options.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+from policyengine_taxsim.runners.remote_taxsim_runner import RemoteTaxsimRunner
+from policyengine_taxsim.runners.taxsim_runner import TaxsimRunner
+
+
+def _taxsim_input(**overrides):
+    row = {
+        "taxsimid": 1,
+        "year": 2020,
+        "state": 6,
+        "mstat": 1,
+        "page": 40,
+        "sage": 0,
+        "depx": 0,
+        "pwages": 50_000,
+    }
+    row.update(overrides)
+    return pd.DataFrame([row])
+
+
+def test_local_taxsim_input_preserves_option_columns():
+    df = _taxsim_input(opt1=30, opt1v=1)
+    runner = TaxsimRunner.__new__(TaxsimRunner)
+
+    formatted = runner._format_input_for_taxsim(df)
+
+    assert formatted["opt1"].tolist() == [30]
+    assert formatted["opt1v"].tolist() == [1]
+    assert runner._dynamic_columns[-2:] == ["opt1", "opt1v"]
+
+
+def test_remote_taxsim_input_preserves_option_columns():
+    df = _taxsim_input(opt1=30, opt1v=1)
+    runner = RemoteTaxsimRunner(df)
+
+    csv_text = runner._format_input(runner.input_df)
+    lines = csv_text.strip().splitlines()
+    header = lines[0].split(",")
+    values = lines[1].split(",")
+
+    assert header[-2:] == ["opt1", "opt1v"]
+    assert values[header.index("opt1")] == "30"
+    assert values[header.index("opt1v")] == "1"
+
+
+def test_remote_taxsim_option_columns_default_to_zero():
+    df = _taxsim_input()
+    runner = RemoteTaxsimRunner(df)
+
+    csv_text = runner._format_input(runner.input_df)
+    lines = csv_text.strip().splitlines()
+    header = lines[0].split(",")
+    values = lines[1].split(",")
+
+    assert header[-2:] == ["opt1", "opt1v"]
+    assert values[header.index("opt1")] == "0"
+    assert values[header.index("opt1v")] == "0"


### PR DESCRIPTION
Fixes #539.

## Summary
- Preserve `opt1` and `opt1v` when formatting hosted TAXSIM-35 requests.
- Add regression coverage for local and remote TAXSIM option-column pass-through.
- Add a changelog entry.

NBER documents option 30 as a TAXSIM option available through the low-level TAXSIM option mechanism: https://taxsim.nber.org/taxsimtest/options.html

## Tests
- `uv run --frozen --python 3.13 pytest tests/test_taxsim_options.py`
- `uv run --frozen --python 3.13 pytest tests/test_taxsim_options.py tests/test_stitched_runner.py`
- `uv run --frozen --python 3.13 ruff format --check policyengine_taxsim/runners/remote_taxsim_runner.py tests/test_taxsim_options.py`
- `git diff --check`