### PR TITLE
Cap TAXSIM dependent age columns at age10

### DIFF
--- a/changelog.d/cap-dependent-ages-at-10.fixed.md
+++ b/changelog.d/cap-dependent-ages-at-10.fixed.md
@@ -1,0 +1,1 @@
+Cap TAXSIM dependent age columns at age10 (age11+ is rejected by taxsimtest with STOP 901), allowing comparison runs that include records with 11+ dependents.

--- a/policyengine_taxsim/runners/taxsim_runner.py
+++ b/policyengine_taxsim/runners/taxsim_runner.py
@@ -233,11 +233,7 @@ class TaxsimRunner(BaseTaxRunner):
             columns_to_use = [
                 c
                 for c in columns_to_use
-                if not (
-                    c.startswith("age")
-                    and c[3:].isdigit()
-                    and int(c[3:]) > 10
-                )
+                if not (c.startswith("age") and c[3:].isdigit() and int(c[3:]) > 10)
             ]
 
             # Write header

--- a/policyengine_taxsim/runners/taxsim_runner.py
+++ b/policyengine_taxsim/runners/taxsim_runner.py
@@ -23,7 +23,9 @@ class TaxsimRunner(BaseTaxRunner):
         "depx",  # 6. Number of dependents
     ]
 
-    # Dependent ages come after depx according to official docs
+    # Dependent ages come after depx according to official docs.
+    # TAXSIM-35 (taxsimtest) only recognizes age1..age10; age11 is rejected
+    # with STOP 901 ("not a taxsimtest input variable").
     DEPENDENT_AGE_COLUMNS = [
         "age1",
         "age2",
@@ -35,7 +37,6 @@ class TaxsimRunner(BaseTaxRunner):
         "age8",
         "age9",
         "age10",
-        "age11",
     ]
 
     # TAXSIM32 format columns for dependent counts by age bracket
@@ -179,8 +180,9 @@ class TaxsimRunner(BaseTaxRunner):
             # Start with required columns
             dynamic_columns = self.REQUIRED_COLUMNS.copy()
 
-            # Add only age columns for actual dependents (up to 11 max)
-            for i in range(min(depx, 11)):
+            # Add only age columns for actual dependents (up to 10 max;
+            # TAXSIM-35 rejects age11 and above).
+            for i in range(min(depx, 10)):
                 age_col = f"age{i + 1}"
                 dynamic_columns.append(age_col)
 
@@ -224,6 +226,19 @@ class TaxsimRunner(BaseTaxRunner):
         with open(temp_file.name, "w") as f:
             # Use dynamic columns if available, otherwise fall back to ALL_COLUMNS
             columns_to_use = getattr(self, "_dynamic_columns", self.ALL_COLUMNS)
+
+            # Defensive guard: TAXSIM-35 only recognizes age1..age10. Drop any
+            # higher dependent-age column so a single record with depx >= 11
+            # cannot abort the entire run with STOP 901.
+            columns_to_use = [
+                c
+                for c in columns_to_use
+                if not (
+                    c.startswith("age")
+                    and c[3:].isdigit()
+                    and int(c[3:]) > 10
+                )
+            ]
 
             # Write header
             f.write(",".join(columns_to_use) + "\n")


### PR DESCRIPTION
## Summary
The `taxsimtest` binary recognizes dependent age variables `age1`..`age10` only — `age11` is rejected with `STOP 901` ("not a taxsimtest input variable"), which aborts the **entire** run. Any input containing a record with `depx >= 11` (2 such records exist in the full CPS) therefore broke full-dataset comparison runs; only smaller samples that happened to exclude those records succeeded.

## Changes
- `taxsim_runner.py`: drop `age11` from `DEPENDENT_AGE_COLUMNS`, cap the per-record age loop at `min(depx, 10)`, and add a defensive write-time filter that strips any `age>10` column from the header before invoking the binary.

## Impact
Enables full-eCPS (111,347-record) comparison runs across 2021–2025; previously these failed and the dashboard was limited to a 3,000-record sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)