### PR TITLE
Dashboard: fix PolicyEngine favicon under basePath

### DIFF
--- a/changelog.d/dashboard-favicon.fixed.md
+++ b/changelog.d/dashboard-favicon.fixed.md
@@ -1,0 +1,1 @@
+Fix the dashboard favicon: prefix the icon path with the basePath so the PolicyEngine icon resolves under /us/taxsim instead of 404ing at the domain root.

--- a/dashboard/src/app/layout.jsx
+++ b/dashboard/src/app/layout.jsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import Header from '@/components/Header';
+import { assetUrl } from '@/utils/basePath';
 
 const GA_ID = 'G-2YHG89FY0N';
 
@@ -21,8 +22,8 @@ export const metadata = {
       'The next chapter of TAXSIM. Open-source, drop-in compatible tax calculator powered by PolicyEngine.',
   },
   icons: {
-    icon: '/policyengine.png',
-    apple: '/policyengine.png',
+    icon: assetUrl('/policyengine.png'),
+    apple: assetUrl('/policyengine.png'),
   },
   alternates: {
     canonical: 'https://policyengine.org/us/taxsim',


### PR DESCRIPTION
## Summary
The dashboard's favicon never loaded: `metadata.icons` pointed at `/policyengine.png`, which resolves to the **domain root** (`policyengine.org/policyengine.png` → 404) rather than the app's `/us/taxsim` basePath. Next.js does not auto-prefix `metadata.icons` with basePath.

## Fix
Prefix the icon path with the existing `assetUrl` helper so the emitted link is `/us/taxsim/policyengine.png` (which returns 200). The PolicyEngine icon now shows in the browser tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)