### PR TITLE
Zero imputed MA SSI state supplement for Senior Circuit Breaker income

### DIFF
--- a/changelog.d/ma-state-supplement-circuit-breaker.fixed.md
+++ b/changelog.d/ma-state-supplement-circuit-breaker.fixed.md
@@ -1,0 +1,1 @@
+Zero the imputed Massachusetts SSI state supplement so it does not inflate the Senior Circuit Breaker total income, matching TAXSIM (which does not model it).

--- a/policyengine_taxsim/core/input_mapper.py
+++ b/policyengine_taxsim/core/input_mapper.py
@@ -225,6 +225,17 @@ def form_household_situation(year, state, taxsim_vars):
             "commodity_supplemental_food_program"
         ] = {str(year): 0}
 
+    # Explicitly set the Massachusetts SSI state supplement to 0 so PolicyEngine
+    # does not impute it. TAXSIM does not model it, and Massachusetts counts cash
+    # public assistance (including SSI) in the Senior Circuit Breaker "total
+    # income" (MGL c.62 s.6(k)), so an imputed supplement understates the credit.
+    # See PolicyEngine/policyengine-taxsim#1031.
+    if state.upper() == "MA":
+        for person_name in household_situation["people"]:
+            household_situation["people"][person_name]["ma_state_supplement"] = {
+                str(year): 0
+            }
+
     # Explicitly set imputed medical expenses to 0 for all people. TAXSIM has no
     # medical-expense input, so PE's imputed Medicare Part B premiums would
     # otherwise flow through the federal itemized medical deduction into state

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -159,6 +159,7 @@ class TaxsimMicrosimDataset(Dataset):
             "ak_energy_relief",
             "ak_permanent_fund_dividend",
             "ssi",  # SSI should be 0 to match TAXSIM (which doesn't model SSI)
+            "ma_state_supplement",  # MA SSI state supplement should be 0 to match TAXSIM (which doesn't model it); it feeds the MA Senior Circuit Breaker income
             "wic",  # WIC should be 0 to match TAXSIM (which doesn't model WIC)
             "snap",  # SNAP should be 0 to match TAXSIM (which doesn't model SNAP)
             "tanf",  # TANF should be 0 to match TAXSIM (which doesn't model TANF)
@@ -829,6 +830,9 @@ class TaxsimMicrosimDataset(Dataset):
                 data["ssi"][year_int] = np.zeros(
                     total_people_for_year
                 )  # Set SSI to 0 to match TAXSIM (which doesn't model SSI)
+                data["ma_state_supplement"][year_int] = np.zeros(
+                    total_people_for_year
+                )  # Set MA SSI state supplement to 0 to match TAXSIM; it feeds the MA Senior Circuit Breaker total income (MGL c.62 s.6(k)). See issue #1031.
                 data["wic"][year_int] = np.zeros(
                     total_people_for_year
                 )  # Set WIC to 0 to match TAXSIM (which doesn't model WIC)


### PR DESCRIPTION
**Draft for review.** Fixes the Massachusetts Senior Circuit Breaker discrepancy in [#1031](https://github.com/PolicyEngine/policyengine-taxsim/issues/1031).

## What

The MA Senior Circuit Breaker counts cash public assistance — including SSI — in its "total income" (MGL c.62 §6(k) / Schedule CB). PolicyEngine imputes a Massachusetts SSI **state supplement** (`ma_state_supplement`) for low-income elderly filers, which inflates the circuit-breaker income and **understates** the credit relative to TAXSIM/TaxAct (which don't model it).

The emulator already zeroes SSI, SNAP and TANF for exactly this reason, but missed `ma_state_supplement`. This zeroes it in both paths:
- `runners/policyengine_runner.py` (the Microsimulation/CLI path) — registers `ma_state_supplement` in the dataset column set and sets it to 0 per person.
- `core/input_mapper.py` (the single-household path) — zeroes it for MA records.

## Result (MA single elderly renter, #1031)

| | circuit-breaker income | credit |
|---|---|---|
| Before | $5,152 (incl. imputed $1,545.84 supplement) | $556 |
| **After** | $3,606 | **$710.57** |

Matches the attached Schedule CB ($710). Verified via the emulator CLI on the #1031 input.

## Scope

MA only for now. Other states' circuit breakers may treat the state supplement differently, so a blanket zeroing of all states' supplements is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
