### PR TITLE
Split KY/OK pension 50/50 for mixed-age couples (age-independent exclusions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 dashboard/public/sample_input_large.csv
+fort.*

--- a/changelog.d/fix-age-independent-pension-split.fixed.md
+++ b/changelog.d/fix-age-independent-pension-split.fixed.md
@@ -1,0 +1,1 @@
+Split KY and OK pension 50/50 for mixed-age couples: their retirement exclusions are per-person and age-independent, so routing the whole pension to the older spouse stranded the younger spouse's exclusion. Adds KY and OK to the per-state split-age table with age 0 (taxsim #965/#966/#1026).

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -212,6 +212,12 @@ class TaxsimMicrosimDataset(Dataset):
     # age, e.g. GA), so gssi always uses the default age; routing it on the
     # higher pension age over-allocates SS to the older spouse and diverges
     # from TAXSIM (eCPS record #27269: GA 68/60, SS over-excluded at a 62 gate).
+    #
+    # A threshold of 0 marks a state whose per-person pension exclusion is
+    # *age-independent* (KY, OK): every filer qualifies, so spouses are always
+    # on the same side and the pension always splits 50/50 — never routed to
+    # the older spouse. Routing would strand the younger spouse's exclusion,
+    # diverging from TAXSIM and TaxAct (taxsim #965 KY, #966 OK, #1026 KY).
     _AGE_GATED_FIELDS = frozenset(
         {"taxable_private_pension_income", "social_security_retirement"}
     )
@@ -221,6 +227,13 @@ class TaxsimMicrosimDataset(Dataset):
         # 65+. A 65/61 couple must route the pension to the 65-year-old or
         # the 61-year-old's half is stranded (taxsim #1027).
         "GA": 62,
+        # KRS §141.019: Kentucky exempts up to $31,110 of retirement income
+        # per person with no age requirement — always split 50/50 so both
+        # spouses claim it (taxsim #965, #1026).
+        "KY": 0,
+        # 68 O.S. §2358: Oklahoma exempts up to $10,000 of retirement income
+        # per person with no age requirement — always split 50/50 (taxsim #966).
+        "OK": 0,
     }
     # TAXSIM source column for pension income (the per-state age applies here
     # only; gssi and any other age-gated field use the default).

--- a/tests/test_spouse_income_splitting.py
+++ b/tests/test_spouse_income_splitting.py
@@ -179,6 +179,27 @@ def test_pension_splits_for_ga_couple_55_to_61_both_below_62():
     np.testing.assert_allclose(values, [40000.0, 40000.0])
 
 
+def test_pension_splits_for_ky_mixed_age_independent_exclusion():
+    """Pension, age-independent state: Kentucky's $31,110 retirement exclusion
+    is per-person with no age requirement (split age 0), so a mixed-age couple
+    still splits 50/50. Routing to the older spouse would strand the younger
+    spouse's exclusion — TAXSIM and TaxAct give both (taxsim #965, #1026).
+    state=18 is KY."""
+    df = pd.DataFrame([_base_mfj_record(state=18, page=59, sage=37, pensions=71414.92)])
+    values = _run_allocation(df, "taxable_private_pension_income")
+    np.testing.assert_allclose(values, [35707.46, 35707.46])
+
+
+def test_pension_splits_for_ok_mixed_age_independent_exclusion():
+    """Pension, age-independent state: Oklahoma's $10,000 retirement exclusion
+    is per-person with no age requirement (split age 0), so a mixed-age couple
+    splits 50/50 rather than routing to the older spouse (taxsim #966).
+    state=37 is OK."""
+    df = pd.DataFrame([_base_mfj_record(state=37, page=59, sage=37, pensions=40000)])
+    values = _run_allocation(df, "taxable_private_pension_income")
+    np.testing.assert_allclose(values, [20000.0, 20000.0])
+
+
 def test_gssi_ignores_per_state_pension_age_for_ga_straddle():
     """gssi: the per-state pension age (GA 62) applies to the pension field
     only, NOT to Social Security. A GA 65/61 couple straddles GA's 62


### PR DESCRIPTION
Fixes the KY/OK cases in #1026, #965, #966.

## What

Kentucky (KRS §141.019, $31,110/person) and Oklahoma (68 O.S. §2358, $10,000/person) exempt retirement income **per person with no age requirement**. The mixed-age *route-to-older* rule dumped the whole household pension on the older spouse and **stranded the younger spouse's exclusion**.

Add KY, OK to `_PENSION_SPLIT_AGE_BY_STATE` with split-age **0** — every filer qualifies, so spouses are always on the same side and the pension always splits 50/50. Reuses the per-state mechanism from #1036; no new logic.

## Why it's correct (verified vs the current NBER binary + TaxAct)

| | PE before | PE after | TAXSIM |
|---|---|---|---|
| KY #1026 (59/37) siitax | $3,278.28 | **$2,023.77** | $2,023.77 (exact) |
| OK (59/37) state taxable | 95,300 | **85,300** | 85,300 (exact) |
| GA #1027 (65/61) | $0 | $0 | $0 (no regression) |

feenberg established in #965 that **TaxAct agrees with TAXSIM** here (both spouses get the exclusion). The $22 residual on OK siitax is a separate OK tax-computation difference on identical taxable income — orthogonal to the split.

## Scope

Only **KY/OK mixed-age** pension records change (route → 50/50). Both-same-side KY/OK couples already split 50/50, so nothing else moves. All other states are untouched.

## Tests

`tests/test_spouse_income_splitting.py` (24 passing) adds KY 59/37 and OK 59/37 → 50/50, alongside the existing GA/CO/both-young/mixed-age cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
