### PR TITLE
Split KY pension 50/50 for mixed-age couples (age-independent exclusion)

### DIFF
--- a/changelog.d/fix-ky-pension-split.fixed.md
+++ b/changelog.d/fix-ky-pension-split.fixed.md
@@ -1,0 +1,1 @@
+Split KY pension 50/50 for mixed-age couples: KY's $31,110 exclusion is per-person and age-independent (KRS §141.019), and TAXSIM's kytax combined cap equals the 50/50 result, so routing to the older spouse stranded the younger spouse's exclusion (taxsim #1026).

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -221,6 +221,12 @@ class TaxsimMicrosimDataset(Dataset):
         # 65+. A 65/61 couple must route the pension to the 65-year-old or
         # the 61-year-old's half is stranded (taxsim #1027).
         "GA": 62,
+        # KRS §141.019: Kentucky exempts up to $31,110 of retirement income
+        # per person with no age requirement (Schedule P). TAXSIM's kytax caps
+        # the combined pension at $31,110*nret, which equals a 50/50 split with
+        # the per-person cap — so KY must split 50/50 at every age rather than
+        # route to the older spouse (taxsim #1026). Age 0 = always same-side.
+        "KY": 0,
     }
     # TAXSIM source column for pension income (the per-state age applies here
     # only; gssi and any other age-gated field use the default).

--- a/tests/test_spouse_income_splitting.py
+++ b/tests/test_spouse_income_splitting.py
@@ -179,6 +179,17 @@ def test_pension_splits_for_ga_couple_55_to_61_both_below_62():
     np.testing.assert_allclose(values, [40000.0, 40000.0])
 
 
+def test_pension_splits_for_ky_mixed_age_independent_exclusion():
+    """Pension, age-independent state: Kentucky's $31,110 retirement exclusion
+    is per-person with no age requirement (Schedule P), and kytax caps the
+    combined pension at $31,110*nret == the 50/50-split result. So a mixed-age
+    KY couple splits 50/50 rather than routing to the older spouse, which would
+    strand the younger spouse's exclusion (taxsim #1026). state=18 is KY."""
+    df = pd.DataFrame([_base_mfj_record(state=18, page=59, sage=37, pensions=71414.92)])
+    values = _run_allocation(df, "taxable_private_pension_income")
+    np.testing.assert_allclose(values, [35707.46, 35707.46])
+
+
 def test_gssi_ignores_per_state_pension_age_for_ga_straddle():
     """gssi: the per-state pension age (GA 62) applies to the pension field
     only, NOT to Social Security. A GA 65/61 couple straddles GA's 62


### PR DESCRIPTION
Fixes the KY case in #1026 / #965.

## What

Kentucky's retirement exclusion (KRS §141.019, $31,110/person, Schedule P) is per-person and **age-independent**, and TAXSIM's `kytax` caps the combined pension at `$31,110·nret` — which is **algebraically identical** to a 50/50 split with the per-person cap (`min(combined, $62,220)`). So a mixed-age KY couple must **split 50/50**, not route the whole pension to the older spouse, which stranded the younger spouse's exclusion.

Adds `"KY": 0` to `_PENSION_SPLIT_AGE_BY_STATE` (mechanism from #1036): both spouses always on the same side → always 50/50.

## Verified

| | PE before | PE after | TAXSIM |
|---|---|---|---|
| KY #1026 (59/37) siitax | $3,278.28 | **$2,023.77** | $2,023.77 (exact) |
| GA #1027 | $0 | $0 | $0 (no regression) |

## Scope

Only KY **mixed-age** pension records change (route → 50/50); both-same-side KY couples already split. An eCPS KY sweep showed the aggregate match rate unchanged — KY's remaining population divergences are a *separate* eligibility issue (PE applies the exclusion to non-qualifying/working-age pension income), not allocation, and split direction is immaterial there.

## Tests

`tests/test_spouse_income_splitting.py` (23 passing) adds KY 59/37 → 50/50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
