### PR TITLE
Map TAXSIM scorp to s_corp_income leaf (coordinate with pe-us #8613)

### DIFF
--- a/changelog.d/map-scorp-to-s-corp-income.changed.md
+++ b/changelog.d/map-scorp-to-s-corp-income.changed.md
@@ -1,0 +1,1 @@
+Map TAXSIM scorp to the s_corp_income leaf instead of the combined partnership_s_corp_income variable, coordinating with policyengine-us#8613 (which split pass-through income into partnership_income and s_corp_income). S-corp income is not subject to self-employment tax, so it must map to the S-corp leaf; partnership_income stays 0 (taxsim #977).

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -799,7 +799,7 @@ taxsim_to_policyengine:
       - self_employment_income:
           - psemp
           - ssemp
-      - partnership_s_corp_income:
+      - s_corp_income:
           - scorp
       - qualified_business_income:
           - pbusinc

--- a/policyengine_taxsim/core/input_mapper.py
+++ b/policyengine_taxsim/core/input_mapper.py
@@ -27,7 +27,7 @@ def add_additional_units(state, year, situation, taxsim_vars):
         "taxable_interest_income",
         "qualified_dividend_income",
         "long_term_capital_gains",
-        "partnership_s_corp_income",
+        "s_corp_income",
         "taxable_private_pension_income",
         "short_term_capital_gains",
         "social_security_retirement",

--- a/policyengine_taxsim/core/yaml_generator.py
+++ b/policyengine_taxsim/core/yaml_generator.py
@@ -189,7 +189,7 @@ class PETestsYAMLGenerator:
                 "long_term_capital_gains",
                 "short_term_capital_gains",
                 "rental_income",
-                "partnership_s_corp_income",
+                "s_corp_income",
                 "qualified_business_income",
                 "w2_wages_from_qualified_business",
                 "business_is_sstb",

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -191,7 +191,7 @@ class TaxsimMicrosimDataset(Dataset):
             "taxable_interest_income",
             "qualified_dividend_income",
             "long_term_capital_gains",
-            "partnership_s_corp_income",
+            "s_corp_income",
             "short_term_capital_gains",
         }
     )

--- a/tests/test_spouse_income_splitting.py
+++ b/tests/test_spouse_income_splitting.py
@@ -55,7 +55,7 @@ def _base_mfj_record(taxsimid=1, **overrides):
         ("dividends", "qualified_dividend_income", 80000),
         ("ltcg", "long_term_capital_gains", 60000),
         ("stcg", "short_term_capital_gains", 30000),
-        ("scorp", "partnership_s_corp_income", 50000),
+        ("scorp", "s_corp_income", 50000),
     ],
 )
 def test_mfj_household_income_splits_between_spouses(taxsim_field, pe_var, amount):
@@ -65,6 +65,18 @@ def test_mfj_household_income_splits_between_spouses(taxsim_field, pe_var, amoun
     # Two people (primary + spouse). Each should get half.
     assert len(values) == 2
     np.testing.assert_allclose(values, [amount / 2, amount / 2])
+
+
+def test_scorp_maps_to_s_corp_income_not_partnership():
+    """TAXSIM `scorp` is S-corporation income, which is not subject to
+    self-employment tax. It must map to the `s_corp_income` leaf, not the
+    partnership leaf (taxsim #977, coordinating with policyengine-us#8613).
+    `partnership_income` should stay 0."""
+    df = pd.DataFrame([_base_mfj_record(scorp=50000)])
+    s_corp = _run_allocation(df, "s_corp_income")
+    partnership = _run_allocation(df, "partnership_income")
+    np.testing.assert_allclose(s_corp, [25000.0, 25000.0])
+    np.testing.assert_allclose(partnership, [0.0, 0.0])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #977. Coordinates with PolicyEngine/policyengine-us#8613 (which split combined pass-through income into `partnership_income` and `s_corp_income` leaves, with `partnership_s_corp_income` now a computed `adds` sum).

## What

Map TAXSIM `scorp` to the **`s_corp_income`** leaf instead of the combined `partnership_s_corp_income`. S-corporation income is not subject to self-employment tax, so it belongs on the S-corp leaf, not partnership. Updated in all four places that referenced the combined name:
- `config/variable_mappings.yaml` (input mapping `scorp → s_corp_income`)
- `runners/policyengine_runner.py` `_SPLITTABLE_VARIABLES` (keeps the MFJ 50/50 split)
- `core/input_mapper.py` `income_types_to_split`
- `core/yaml_generator.py`

Per #977, `psemp`/`ssemp` are unchanged, and nothing infers `partnership_self_employment_net_earnings` (TAXSIM has no K-1 Box 14 field).

## Behavior-neutral (verified)

CA single, $50K scorp: `fiitax $3,049.50`, `siitax $1,039.53`, `v10 $50,000` — **identical before and after** (since `partnership_s_corp_income = partnership_income(0) + s_corp_income` downstream). The change just routes `scorp` to the correct leaf.

## Tests

`tests/test_spouse_income_splitting.py` (24 passing): the MFJ split test now targets `s_corp_income`, plus a new `test_scorp_maps_to_s_corp_income_not_partnership` asserting `scorp` populates `s_corp_income` 50/50 and leaves `partnership_income` at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
