### PR TITLE
Map fica output to taxsim_fica (combined employee+employer FICA)

### DIFF
--- a/changelog.d/fix-fica-mapping.fixed.md
+++ b/changelog.d/fix-fica-mapping.fixed.md
@@ -1,0 +1,1 @@
+Map the `fica` output column to the PolicyEngine-US `taxsim_fica` variable (combined employee + employer FICA) instead of the na_pe sentinel, which always emitted 0.0.

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -55,7 +55,7 @@ policyengine_to_taxsim:
     full_text_group: "Basic Output"
     group_column: 1
   fica:
-    variable: na_pe
+    variable: taxsim_fica
     implemented: true
     idtl:
       - standard: 0

--- a/tests/test_fica_output.py
+++ b/tests/test_fica_output.py
@@ -1,0 +1,56 @@
+"""
+Regression test for the `fica` output column.
+
+TAXSIM's `fica` column is the *combined* employee + employer FICA (OASDI +
+HI, including Additional Medicare Tax); `tfica` is the employee-only half.
+The `fica` column was mapped to the `na_pe` sentinel (always 0.0) even after
+the PolicyEngine-US `taxsim_fica` variable shipped, so the emulator emitted
+0.0 for FICA. This maps `fica -> taxsim_fica` so the combined amount is
+emitted. See policyengine-taxsim#21.
+"""
+
+import io
+
+import pandas as pd
+from click.testing import CliRunner
+
+from policyengine_taxsim.cli import cli
+
+
+def _fica_columns(pwages: int = 10000):
+    """Run a single-earner record and return (fica, tfica) from CSV output."""
+    record = (
+        "taxsimid,year,state,mstat,page,sage,depx,pwages,idtl\n"
+        f"1,2025,0,1,40,0,0,{pwages},2\n"
+    )
+    result = CliRunner().invoke(cli, [], input=record)
+    assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+    # The CSV header line begins with "taxsimid," (a tqdm progress bar may
+    # be prepended to the same physical line, so split on that prefix).
+    for line in result.output.splitlines():
+        idx = line.find("taxsimid,")
+        if idx != -1:
+            header = line[idx:]
+            data_start = result.output.index(header) + len(header)
+            data_line = result.output[data_start:].splitlines()[1]
+            df = pd.read_csv(io.StringIO(header + "\n" + data_line))
+            return df["fica"].iloc[0], df["tfica"].iloc[0]
+    raise AssertionError(f"No CSV header found in output:\n{result.output}")
+
+
+def test_fica_is_combined_employee_and_employer():
+    """$10,000 wages → employee 7.65% ($765) + employer 7.65% ($765) = $1,530."""
+    fica, tfica = _fica_columns(pwages=10000)
+    assert fica == 1530.0, f"expected combined FICA 1530.0, got {fica}"
+
+
+def test_tfica_is_employee_half():
+    """tfica is the employee-only half ($765) — regression guard."""
+    _, tfica = _fica_columns(pwages=10000)
+    assert tfica == 765.0, f"expected employee FICA 765.0, got {tfica}"
+
+
+def test_fica_is_not_zeroed():
+    """`fica` must not regress to the old na_pe sentinel (0.0)."""
+    fica, _ = _fica_columns(pwages=10000)
+    assert fica != 0.0, "fica regressed to na_pe sentinel (0.0)"


### PR DESCRIPTION
## Summary
The `fica` output column was mapped to the `na_pe` sentinel and always emitted **0.0**, even after the PolicyEngine-US `taxsim_fica` variable shipped (pe-us #8294 / PR #8383). This points `fica` at `taxsim_fica`, so the emulator emits the **combined employee + employer** FICA (OASDI + HI, incl. Additional Medicare Tax) that TAXSIM reports. `tfica` (employee-only half) already mapped correctly.

## Verification
Single-earner record ($10,000 wages, 2025) through the emulator:
- Before: `fica = 0.0`
- After: `fica = 1530.0` (employee $765 + employer $765), `tfica = 765.0` — matching the TAXSIM-35 binary.

## Test
Adds `tests/test_fica_output.py` (3 cases: combined = 1530, employee half = 765, not-zeroed regression guard).

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)