### PR TITLE
Zero PE-imputed transfers via set_input (fixes MA Senior Circuit Breaker, #1031)

### DIFF
--- a/changelog.d/fix-transfer-zeroing-setinput.fixed.md
+++ b/changelog.d/fix-transfer-zeroing-setinput.fixed.md
@@ -1,0 +1,1 @@
+Zero PE-imputed means-tested transfers (SSI, SNAP, TANF, WIC, and state SSI supplements) via set_input so they don't leak into state calculations that count cash public assistance as income (e.g. the Massachusetts Senior Circuit Breaker).

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -33,6 +33,29 @@ from policyengine_us import Microsimulation
 from policyengine_core.data import Dataset
 
 
+# Means-tested transfers that PE imputes but TAXSIM has no input column for.
+# They must be forced to 0 (via set_input, after the sim is built — the
+# dataset-level zeroing of these formula-based variables is silently
+# recomputed by the Microsimulation) so PE's imputed benefits do not leak
+# into state calculations that count cash public assistance as income
+# (e.g. the MA Senior Circuit Breaker; taxsim #1031). Includes the federal
+# programs and every state SSI supplement PE models.
+_ZERO_IMPUTED_TRANSFERS = frozenset(
+    {
+        "ssi",
+        "snap",
+        "tanf",
+        "wic",
+        "ma_state_supplement",
+        "ca_state_supplement",
+        "co_state_supplement",
+        "nm_ssi_state_supplement",
+        "sc_ssi_state_supplement",
+        "tx_ssi_state_supplement",
+    }
+)
+
+
 class TaxsimMicrosimDataset(Dataset):
     """Custom dataset for TAXSIM data using PolicyEngine Microsimulation."""
 
@@ -1113,6 +1136,33 @@ class PolicyEngineRunner(BaseTaxRunner):
                                     else year
                                 ),
                             )
+
+            # PE imputes means-tested transfers (SSI, SNAP, TANF, WIC, and
+            # state SSI supplements) from the microsimulation's low-income
+            # records. TAXSIM has no input columns for any of these, so they
+            # must be zeroed to match TAXSIM's transfer-free world — otherwise
+            # PE's imputed benefits leak into state calculations that count
+            # cash public assistance as income (e.g. the MA Senior Circuit
+            # Breaker base, MGL c.62 §6(k); taxsim #1031). These are
+            # formula-based benefit variables, so the dataset-level zeroing is
+            # silently recomputed by the Microsimulation; they must be forced
+            # off with set_input after the sim is built (same mechanism as the
+            # overrides above), which set_input holds as a fixed input.
+            years = sorted(set(chunk_df["year"].unique()))
+            for var in _ZERO_IMPUTED_TRANSFERS:
+                if var not in sim.tax_benefit_system.variables:
+                    continue
+                n_entities = sim.get_variable_population(var).count
+                for year in years:
+                    sim.set_input(
+                        variable_name=var,
+                        value=np.zeros(n_entities),
+                        period=str(
+                            int(year)
+                            if isinstance(year, (float, np.floating))
+                            else year
+                        ),
+                    )
 
             return self._extract_vectorized_results(sim, chunk_df)
 

--- a/tests/test_imputed_transfers_zeroed.py
+++ b/tests/test_imputed_transfers_zeroed.py
@@ -1,0 +1,45 @@
+"""
+Regression test for zeroing PE-imputed means-tested transfers.
+
+TAXSIM has no input columns for SSI, SNAP, TANF, WIC or state SSI
+supplements. PolicyEngine imputes these for low-income records, and they
+leak into state calculations that count cash public assistance as income —
+most visibly the Massachusetts Senior Circuit Breaker (MGL c.62 §6(k)),
+which zeroes out the credit for a low-income elderly renter.
+
+These are formula-based benefit variables, so zeroing them in the dataset is
+silently recomputed by the Microsimulation; the runner forces them to 0 with
+set_input after building the sim. See policyengine-taxsim#1031.
+"""
+
+import io
+
+import pandas as pd
+from click.testing import CliRunner
+
+from policyengine_taxsim.cli import cli
+
+
+def _siitax(record: str) -> float:
+    result = CliRunner().invoke(cli, [], input=record)
+    assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+    out = result.output
+    idx = out.find("taxsimid,")
+    assert idx != -1, f"No CSV output:\n{out}"
+    df = pd.read_csv(io.StringIO(out[idx:]))
+    return float(df["siitax"].iloc[0])
+
+
+def test_ma_senior_circuit_breaker_not_wiped_by_imputed_transfers():
+    """MA single elderly renter (#1031): SSI/SNAP/state-supplement must not
+    inflate the circuit-breaker income base. Credit should be ~$710.57
+    (refundable → negative siitax), matching TAXSIM/TaxAct, not $0."""
+    record = (
+        "taxsimid,year,state,mstat,page,sage,depx,intrec,rentpaid,idtl\n"
+        "1,2025,22,1,69,0,0,4306.37,4284.81,2\n"
+    )
+    siitax = _siitax(record)
+    assert abs(siitax - (-710.57)) < 1.0, (
+        f"expected MA Senior Circuit Breaker siitax ~ -710.57, got {siitax} "
+        "(imputed transfers likely leaking into ma_scb_total_income)"
+    )


### PR DESCRIPTION
## Summary

TAXSIM has no input columns for means-tested transfers, so PolicyEngine's imputed SSI/SNAP/TANF/WIC and state SSI supplements must be zeroed to match TAXSIM's transfer-free world. They were leaking into state calculations that count cash public assistance as income — most visibly the **MA Senior Circuit Breaker** (MGL c.62 §6(k)), which zeroed out the credit for a low-income elderly renter (**#1031**).

## The real bug: the existing zeroing was silently ineffective

`ssi`/`snap`/`tanf` were already listed as "should be 0 to match TAXSIM" and written into the dataset as zeros — but these are **formula-based benefit variables**, and the Microsimulation **recomputes** them, ignoring the dataset value (verified: a situation/dataset input for `ssi` leaves `known_periods = []`). So they've been leaking all along. This is also why the draft PR #1033 (which adds `ma_state_supplement` to the same dataset list) does not actually fix #1031 — I confirmed it still returns siitax `$0`.

## Fix

Force the transfers to 0 with `sim.set_input(...)` **after** the Microsimulation is built (the mechanism already used for `w2_wages`/`rental_income_would_be_qualified`), which is held as a fixed input. Covers the federal programs (`ssi`, `snap`, `tanf`, `wic`) and every state SSI supplement PE models (MA/CA/CO/NM/SC/TX).

## Verification

**MA #1031 record** (single, age 69, `intrec` \$4,306.37, `rentpaid` \$4,284.81):
- Before: siitax **\$0** (`ma_scb_total_income` \$15,217 — imputed SSI \$7,538 + SNAP \$2,528 + state supplement \$1,546)
- After: siitax **−\$710.57** = TAXSIM/TaxAct; `ma_scb_total_income` \$3,606.37 (interest − \$700 exemption) exact.

**eCPS before/after sweep** (fixed 1,000-record TY2021 sample, `--assume-w2-wages`):
- Federal match unchanged (80.7%); state match 66.3% → 66.4%.
- 3 records changed: the MA circuit-breaker case now matches TAXSIM exactly; 2 MI records now compute the **Home Heating Credit** correctly per the standard-allowance formula (\$497 − 3.5% × THR — matches to the dollar), where PE-after is *more* accurate than both PE-before (a −\$155 artifact from inflated THR) and TAXSIM (which under-computes the MI HHC). No true regressions.

Adds `tests/test_imputed_transfers_zeroed.py`.

Closes #1031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)