### PR TITLE
Map pass-through inputs to QBID-bearing PolicyEngine variables

### DIFF
--- a/changelog.d/map-passthrough-qbid-variables.fixed.md
+++ b/changelog.d/map-passthrough-qbid-variables.fixed.md
@@ -1,0 +1,1 @@
+Map TAXSIM pass-through inputs (psemp/ssemp, pbusinc/sbusinc, scorp, pprofinc/sprofinc) to QBID-bearing PolicyEngine variables so S-corp, active QBI, and self-employment income earn the qualified business income deduction.

--- a/dashboard/public/config-data.json
+++ b/dashboard/public/config-data.json
@@ -75,14 +75,14 @@
       "policyengine": "self_employment_income",
       "description": "Self-employment income of primary taxpayer",
       "implemented": true,
-      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/household/income/self_employment/self_employment_income.py"
+      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/input/self_employment_income.py"
     },
     {
       "taxsim": "ssemp",
       "policyengine": "self_employment_income",
       "description": "Self-employment income of secondary taxpayer",
       "implemented": true,
-      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/household/income/self_employment/self_employment_income.py"
+      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/input/self_employment_income.py"
     },
     {
       "taxsim": "dividends",
@@ -149,17 +149,17 @@
     },
     {
       "taxsim": "pbusinc",
-      "policyengine": "qualified_business_income",
-      "description": "Primary and secondary Taxpayer's active QBI",
+      "policyengine": "self_employment_income",
+      "description": "Primary taxpayer's active QBI",
       "implemented": true,
-      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py"
+      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/input/self_employment_income.py"
     },
     {
       "taxsim": "pprofinc",
       "policyengine": "sstb_self_employment_income",
       "description": "Primary taxpayer's SSTB self-employment income",
       "implemented": true,
-      "githubLink": null
+      "githubLink": "https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/variables/input/sstb_self_employment_income.py"
     },
     {
       "taxsim": "rentpaid",
@@ -280,5 +280,5 @@
       }
     ]
   },
-  "lastUpdated": "2026-06-22T00:34:33.871Z"
+  "lastUpdated": "2026-07-05T15:19:19.288Z"
 }

--- a/dashboard/scripts/extract-config.cjs
+++ b/dashboard/scripts/extract-config.cjs
@@ -29,7 +29,8 @@ function generatePolicyEngineGitHubLink(variableName) {
   const variablePathMap = {
     // Income variables
     'employment_income': 'input/employment_income.py',
-    'self_employment_income': 'household/income/self_employment/self_employment_income.py',
+    'self_employment_income': 'input/self_employment_income.py',
+    'sstb_self_employment_income': 'input/sstb_self_employment_income.py',
     'qualified_dividend_income': 'household/income/person/dividends/qualified_dividend_income.py',
     'taxable_interest_income': 'household/income/person/interest/taxable_interest_income.py',
     'short_term_capital_gains': 'household/income/person/capital_gains/short_term_capital_gains.py',

--- a/policyengine_taxsim/api.py
+++ b/policyengine_taxsim/api.py
@@ -76,6 +76,7 @@ KNOWN_COLUMNS = {
     "mortgage",
     "scorp",
     "pbusinc",
+    "sbusinc",
     "pprofinc",
     "sprofinc",
     "idtl",

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -796,13 +796,33 @@ taxsim_to_policyengine:
           - dividends
       - long_term_capital_gains:
           - ltcg
+      # psemp/ssemp (self-employment) and pbusinc/sbusinc (active QBI) both
+      # map to self_employment_income: active-participation income subject to
+      # SECA that flows into the § 199A QBID without the SSTB phaseout. Per
+      # Dan Feenberg's spec, businc is identical to semp (active + SECA +
+      # QBID-without-phaseout), so they share one PolicyEngine variable.
+      # Do NOT map to qualified_business_income: that PE variable is COMPUTED
+      # (from self_employment_income et al. via the QBI income_definition), so
+      # supplying it as a dataset input holds it at that value and zeroes every
+      # other record's non-SSTB QBI. Per-person routing (psemp+pbusinc ->
+      # primary, ssemp+sbusinc -> spouse) is handled in the mapper code.
       - self_employment_income:
           - psemp
           - ssemp
-      - s_corp_income:
-          - scorp
-      - qualified_business_income:
           - pbusinc
+          - sbusinc
+      # scorp maps to partnership_s_corp_income, the variable named in the QBI
+      # income_definition (it adds partnership_income + s_corp_income). Mapping
+      # to the leaf s_corp_income instead held it as a dataset input, which
+      # suppressed its uprating formula; and with qualified_business_income also
+      # held at 0, S-corp income produced correct AGI but no QBID.
+      - partnership_s_corp_income:
+          - scorp
+      # pprofinc/sprofinc (SSTB professional-service income) map to
+      # sstb_self_employment_income: subject to SECA, QBID WITH the
+      # § 199A(d)(3) applicable-percentage phaseout. PE tracks SSTB income in
+      # this dedicated input so the phaseout reduces only the SSTB component;
+      # no business_is_sstb flag is needed on this path.
       - sstb_self_employment_income:
           - pprofinc
           - sprofinc
@@ -886,7 +906,10 @@ taxsim_input_definition:
   - scorp:
       name: "26. S-Corp profits"
   - pbusinc:
-      name: "27. Primary and secondary Taxpayer's active QBI"
+      name: "27. Primary taxpayer's active QBI"
+      pair: sbusinc
+  - sbusinc:
+      name: "27b. Spouse's active QBI"
   - pprofinc:
       name: "28. Primary taxpayer's SSTB self-employment income"
       pair: sprofinc

--- a/policyengine_taxsim/core/input_mapper.py
+++ b/policyengine_taxsim/core/input_mapper.py
@@ -27,7 +27,7 @@ def add_additional_units(state, year, situation, taxsim_vars):
         "taxable_interest_income",
         "qualified_dividend_income",
         "long_term_capital_gains",
-        "s_corp_income",
+        "partnership_s_corp_income",
         "taxable_private_pension_income",
         "short_term_capital_gains",
         "social_security_retirement",
@@ -69,12 +69,24 @@ def add_additional_units(state, year, situation, taxsim_vars):
                 continue
 
             if field == "self_employment_income":
-                if "psemp" in taxsim_vars:
-                    people_unit["you"][field] = {str(year): taxsim_vars.get("psemp", 0)}
-                if "your partner" in people_unit and "ssemp" in taxsim_vars:
-                    people_unit["your partner"][field] = {
-                        str(year): taxsim_vars.get("ssemp", 0)
-                    }
+                # psemp (self-employment) and pbusinc (active QBI) both feed the
+                # primary's self_employment_income; ssemp and sbusinc feed the
+                # spouse's. Both income types are active-participation, SECA-
+                # bearing, and QBID-eligible without the SSTB phaseout, so they
+                # share one PolicyEngine variable (Dan Feenberg: businc is, by
+                # his spec, identical to semp). Summing here — rather than
+                # giving pbusinc a second field — keeps one input from
+                # overwriting the other.
+                primary_se = taxsim_vars.get("psemp", 0) + taxsim_vars.get("pbusinc", 0)
+                if "psemp" in taxsim_vars or "pbusinc" in taxsim_vars:
+                    people_unit["you"][field] = {str(year): primary_se}
+                if "your partner" in people_unit and (
+                    "ssemp" in taxsim_vars or "sbusinc" in taxsim_vars
+                ):
+                    spouse_se = taxsim_vars.get("ssemp", 0) + taxsim_vars.get(
+                        "sbusinc", 0
+                    )
+                    people_unit["your partner"][field] = {str(year): spouse_se}
 
             elif field == "sstb_self_employment_income":
                 if "pprofinc" in taxsim_vars:

--- a/policyengine_taxsim/core/yaml_generator.py
+++ b/policyengine_taxsim/core/yaml_generator.py
@@ -189,8 +189,12 @@ class PETestsYAMLGenerator:
                 "long_term_capital_gains",
                 "short_term_capital_gains",
                 "rental_income",
-                "s_corp_income",
-                "qualified_business_income",
+                # scorp -> partnership_s_corp_income (QBID-bearing aggregate);
+                # pprofinc/sprofinc -> sstb_self_employment_income (QBID with
+                # SSTB phaseout). pbusinc now folds into self_employment_income,
+                # so qualified_business_income is no longer set as an input.
+                "partnership_s_corp_income",
+                "sstb_self_employment_income",
                 "w2_wages_from_qualified_business",
                 "business_is_sstb",
                 "business_is_qualified",

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -191,7 +191,7 @@ class TaxsimMicrosimDataset(Dataset):
             "taxable_interest_income",
             "qualified_dividend_income",
             "long_term_capital_gains",
-            "s_corp_income",
+            "partnership_s_corp_income",
             "short_term_capital_gains",
         }
     )
@@ -264,6 +264,20 @@ class TaxsimMicrosimDataset(Dataset):
         def accessor(row):
             value = float(row.get(source_field, 0))
             return value / 2 if int(row.get("mstat", 1)) == 2 else 0.0
+
+        return accessor
+
+    @staticmethod
+    def _make_sum(*source_fields):
+        """Return a callable summing several TAXSIM columns for one person.
+
+        Used where two per-person TAXSIM inputs feed a single PolicyEngine
+        variable — e.g. psemp (self-employment) + pbusinc (active QBI) both
+        populate the primary's self_employment_income. Each column is already
+        per-person in TAXSIM-35, so no MFJ splitting is applied here."""
+
+        def accessor(row):
+            return sum(float(row.get(f, 0)) for f in source_fields)
 
         return accessor
 
@@ -358,6 +372,21 @@ class TaxsimMicrosimDataset(Dataset):
             if isinstance(item, dict):
                 for pe_var, taxsim_vars in item.items():
                     if not taxsim_vars:  # Skip empty mappings
+                        continue
+
+                    if pe_var == "self_employment_income":
+                        # psemp + pbusinc feed the primary's self_employment_income;
+                        # ssemp + sbusinc feed the spouse's. Both are per-person
+                        # TAXSIM columns (no household splitting), so sum each
+                        # spouse's own pair. Handled explicitly because the
+                        # generic length-based branches below only read the first
+                        # one or two columns of the list.
+                        variable_mapping[pe_var] = {
+                            "primary": self._make_sum("psemp", "pbusinc"),
+                            "spouse": self._make_sum("ssemp", "sbusinc"),
+                            "dependent": 0.0,
+                            "default": 0.0,
+                        }
                         continue
 
                     if len(taxsim_vars) == 1:

--- a/policyengine_taxsim/runners/taxsim_runner.py
+++ b/policyengine_taxsim/runners/taxsim_runner.py
@@ -69,6 +69,10 @@ class TaxsimRunner(BaseTaxRunner):
         "childcare",  # Child care expenses
         "mortgage",  # Mortgage interest
         "scorp",  # S-Corp profits
+        "pbusinc",  # Primary taxpayer's active QBI (QBID, no SSTB phaseout)
+        "sbusinc",  # Spouse's active QBI
+        "pprofinc",  # Primary taxpayer's SSTB self-employment income
+        "sprofinc",  # Spouse's SSTB self-employment income
         "idtl",  # Output control
     ]
 

--- a/tests/test_passthrough_qbid.py
+++ b/tests/test_passthrough_qbid.py
@@ -1,0 +1,317 @@
+"""Regression tests for pass-through income → QBID-bearing PolicyEngine variables.
+
+Dan Feenberg's 2026-06-30 comparison (email to Pavel/Max) ran $100k of gross
+income from five sources through the emulator for a 2025 single filer and found
+the PolicyEngine column diverged from TAXSIM-35 on three of them:
+
+  - pbusinc: mapped to the COMPUTED qualified_business_income variable, which
+    the emulator dataset held as an input at 0 for every record → S-corp/QBI
+    income produced zero AGI and zero tax.
+  - psemp / scorp: correct AGI but NO qualified business income deduction
+    (taxable 77,185 / 84,250 vs TAXSIM's 61,748 / 67,400).
+  - pprofinc / intrec: already correct.
+
+Root cause: the emulator initializes every mapped PolicyEngine variable as a
+dataset input. Mapping pbusinc → qualified_business_income (a variable derived
+from self_employment_income et al. via the § 199A income_definition) held that
+derived value at whatever pbusinc supplied — 0 on all other records — which
+zeroed the non-SSTB QBI component for psemp and scorp too. scorp additionally
+mapped to the s_corp_income leaf rather than partnership_s_corp_income (the
+variable actually named in the QBI income_definition).
+
+Fix (variable_mappings.yaml + mapper code):
+  - psemp/ssemp AND pbusinc/sbusinc → self_employment_income
+    (active participation, SECA, QBID without the SSTB phaseout — Dan's spec
+    treats businc as identical to semp).
+  - scorp → partnership_s_corp_income (QBID, no SECA, NIIT-eligible).
+  - pprofinc/sprofinc → sstb_self_employment_income (QBID WITH the
+    § 199A(d)(3) applicable-percentage phaseout) — unchanged, already correct.
+
+policyengine-us itself was verified correct throughout (a direct Simulation
+with self_employment_income=100k gives AGI 92,935 / taxable 61,748 /
+income_tax 8,499); the defect was purely in this emulator's mapping layer.
+
+Fixes taxsim #384 (FICA and QBI income), #943 (scorp QBID), #1004 (scorp QBID),
+#762 (QBID across pass-through inputs); addresses #1018 and #1003.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from policyengine_taxsim.runners.policyengine_runner import PolicyEngineRunner
+
+
+# TAXSIM-35 target column from Dan's 2026-06-30 five-source comparison
+# (2025 single filer, $100k of a single gross income source, state = TX so no
+# state tax noise). Tuples are (AGI, taxable income, federal income tax).
+# income_tax is asserted with a $1 tolerance because TAXSIM and PE round the
+# half-SECA / QBID chain at different points (Dan's table shows 8,498 where PE
+# gives 8,499).
+DAN_FIVE_SOURCE = {
+    "psemp": (92_935, 61_748, 8_499),
+    "pbusinc": (92_935, 61_748, 8_499),
+    "scorp": (100_000, 67_400, 9_742),
+    "pprofinc": (92_935, 61_748, 8_499),
+    "intrec": (100_000, 84_250, 13_449),
+}
+
+# All income columns that must be present (as 0) so each single-source record
+# carries only its own income.
+_INCOME_COLS = [
+    "psemp",
+    "ssemp",
+    "pbusinc",
+    "sbusinc",
+    "scorp",
+    "pprofinc",
+    "sprofinc",
+    "intrec",
+]
+
+
+def _single_source_frame():
+    """One 2025 TX single-filer record per source, $100k of that source."""
+    rows = []
+    for i, src in enumerate(DAN_FIVE_SOURCE, start=1):
+        rec = {
+            "taxsimid": i,
+            "year": 2025,
+            "state": 44,  # TX — no state income tax
+            "mstat": 1,
+            "depx": 0,
+            "page": 40,
+            "sage": 0,
+            "pwages": 0.0,
+            "swages": 0.0,
+            "idtl": 2,  # full output → exposes v10 (AGI), v18 (taxable), qbid
+        }
+        rec[src] = 100_000.0
+        rows.append(rec)
+    df = pd.DataFrame(rows)
+    for col in _INCOME_COLS:
+        if col not in df.columns:
+            df[col] = 0.0
+        df[col] = df[col].fillna(0.0)
+    return df
+
+
+@pytest.fixture(scope="module")
+def dan_results():
+    """Run all five source records once and index by taxsimid."""
+    df = _single_source_frame()
+    out = PolicyEngineRunner(df.copy()).run(show_progress=False)
+    return out.set_index("taxsimid")
+
+
+@pytest.mark.parametrize(
+    "taxsimid,source",
+    list(enumerate(DAN_FIVE_SOURCE, start=1)),
+)
+def test_dan_five_source_agi_taxable_tax(dan_results, taxsimid, source):
+    """$100k of each source reproduces TAXSIM-35's AGI, taxable income, and
+    federal income tax (Dan Feenberg, 2026-06-30)."""
+    agi, taxable, tax = DAN_FIVE_SOURCE[source]
+    row = dan_results.loc[taxsimid]
+    assert row["v10"] == pytest.approx(agi, abs=1.0), f"{source}: AGI"
+    assert row["v18"] == pytest.approx(taxable, abs=1.0), f"{source}: taxable income"
+    assert row["fiitax"] == pytest.approx(tax, abs=1.0), f"{source}: federal income tax"
+
+
+@pytest.mark.parametrize(
+    "taxsimid,source,expects_qbid",
+    [
+        (1, "psemp", True),  # self-employment → QBID (was 0 before the fix)
+        (2, "pbusinc", True),  # active QBI → QBID (was fully unmapped before)
+        (3, "scorp", True),  # S-corp → QBID via partnership_s_corp_income
+        (4, "pprofinc", True),  # SSTB → QBID with phaseout (below threshold here)
+        (5, "intrec", False),  # interest is not QBI → no QBID
+    ],
+)
+def test_dan_five_source_qbid_present(dan_results, taxsimid, source, expects_qbid):
+    """The four pass-through sources earn a QBID; interest does not.
+
+    Below the phaseout threshold, $100k of qualifying pass-through income minus
+    the half-SECA adjustment (for the SECA-bearing sources) yields a 20 %
+    deduction; the exact figures differ only by whether SECA applies."""
+    qbid = dan_results.loc[taxsimid]["qbid"]
+    if expects_qbid:
+        assert qbid > 0, f"{source}: expected a QBI deduction, got {qbid}"
+    else:
+        assert qbid == pytest.approx(0.0, abs=1.0), (
+            f"{source}: expected no QBID, got {qbid}"
+        )
+
+
+def test_scorp_has_no_seca_but_earns_qbid(dan_results):
+    """S-corp income (partnership_s_corp_income) earns the QBID but is NOT
+    subject to self-employment tax — matching Dan's spec (no FICA/SECA on
+    scorp) and TAXSIM. fica must be 0 while qbid is positive."""
+    row = dan_results.loc[3]  # scorp
+    assert row["fica"] == pytest.approx(0.0, abs=1.0), "scorp should bear no SECA/FICA"
+    assert row["qbid"] > 0, "scorp should still earn a QBID"
+
+
+def test_self_employment_sources_bear_seca(dan_results):
+    """psemp, pbusinc, and pprofinc are active-participation income subject to
+    SECA, so fica (the combined employee+employer FICA/SECA column) is positive
+    for each — distinguishing them from scorp/intrec."""
+    for taxsimid, source in [(1, "psemp"), (2, "pbusinc"), (4, "pprofinc")]:
+        assert dan_results.loc[taxsimid]["fica"] > 0, f"{source} should bear SECA"
+
+
+def _run_single(record, year=2025):
+    """Run one TX single-filer record and return its full-output row."""
+    df = pd.DataFrame([record])
+    for col in _INCOME_COLS + ["w2_wages_from_qualified_business"]:
+        if col not in df.columns:
+            df[col] = 0.0
+        df[col] = df[col].fillna(0.0)
+    out = PolicyEngineRunner(df.copy()).run(show_progress=False)
+    return out.iloc[0]
+
+
+def test_sstb_phaseout_binds_harder_than_non_sstb():
+    """Above the § 199A threshold the SSTB applicable-percentage phaseout bites
+    harder than the non-SSTB wage/UBIA cap: identical dollar amounts of SSTB
+    professional income (pprofinc) and active QBI (pbusinc) yield a strictly
+    smaller QBID for the SSTB.
+
+    2025 single phaseout starts at $197,300 taxable income (excl. QBID), length
+    $50,000. With $260k of income and no W-2 wages/UBIA (the emulator has no
+    per-record W-2 input — TAXSIM never carries one), both categories are
+    reduced above the threshold, but the SSTB's applicable-percentage phaseout
+    reduces it further. The emulator gives pbusinc QBID ~17,143 and pprofinc
+    QBID ~5,983. This pins the ordering and the non-SSTB > SSTB gap so a future
+    mapping edit cannot silently route SSTB income onto the non-phaseout path
+    (or vice-versa).
+
+    (A direct policyengine-us Simulation supplied with large
+    w2_wages_from_qualified_business lifts the non-SSTB QBID to the full 45,970
+    while the SSTB stays capped — confirming the phaseout is SSTB-specific — but
+    the emulator cannot inject that W-2 input per record, so the values here are
+    the emulator's own.)"""
+    base = {
+        "taxsimid": 1,
+        "year": 2025,
+        "state": 44,
+        "mstat": 1,
+        "depx": 0,
+        "page": 40,
+        "sage": 0,
+        "pwages": 0.0,
+        "swages": 0.0,
+        "idtl": 2,
+    }
+    non_sstb = _run_single({**base, "pbusinc": 260_000.0})
+    sstb = _run_single({**base, "pprofinc": 260_000.0})
+
+    assert non_sstb["qbid"] == pytest.approx(17_143, abs=50), (
+        f"non-SSTB pbusinc QBID {non_sstb['qbid']} should be ~17,143"
+    )
+    assert sstb["qbid"] == pytest.approx(5_983, abs=50), (
+        f"SSTB pprofinc QBID {sstb['qbid']} should be the further-phased ~5,983"
+    )
+    # The SSTB applicable-percentage phaseout strictly reduces its deduction
+    # below the non-SSTB one at the same income.
+    assert sstb["qbid"] < non_sstb["qbid"]
+
+
+def test_sstb_qbid_fully_eliminated_far_above_threshold():
+    """Far above the phaseout band ($300k single), SSTB professional income is
+    fully phased out — QBID drops to 0 — confirming the § 199A(d)(3) SSTB
+    treatment reaches complete elimination. pprofinc → sstb_self_employment_income
+    is the mapping under test."""
+    base = {
+        "taxsimid": 1,
+        "year": 2025,
+        "state": 44,
+        "mstat": 1,
+        "depx": 0,
+        "page": 40,
+        "sage": 0,
+        "pwages": 0.0,
+        "swages": 0.0,
+        "idtl": 2,
+    }
+    sstb = _run_single({**base, "pprofinc": 300_000.0})
+    assert sstb["qbid"] == pytest.approx(0.0, abs=1.0), (
+        f"SSTB QBID {sstb['qbid']} should be fully phased out at $300k"
+    )
+
+
+def test_pbusinc_and_psemp_are_identical():
+    """Per Dan's spec, active QBI (businc) is identical to self-employment
+    (semp): same active participation, SECA, and QBID-without-phaseout. $100k
+    of each must produce the same AGI, taxable income, tax, QBID, and FICA."""
+    psemp = _run_single(
+        {
+            "taxsimid": 1,
+            "year": 2025,
+            "state": 44,
+            "mstat": 1,
+            "depx": 0,
+            "page": 40,
+            "sage": 0,
+            "pwages": 0.0,
+            "swages": 0.0,
+            "idtl": 2,
+            "psemp": 100_000.0,
+        }
+    )
+    pbusinc = _run_single(
+        {
+            "taxsimid": 1,
+            "year": 2025,
+            "state": 44,
+            "mstat": 1,
+            "depx": 0,
+            "page": 40,
+            "sage": 0,
+            "pwages": 0.0,
+            "swages": 0.0,
+            "idtl": 2,
+            "pbusinc": 100_000.0,
+        }
+    )
+    for col in ["v10", "v18", "fiitax", "qbid", "fica"]:
+        assert psemp[col] == pytest.approx(pbusinc[col], abs=1.0), f"mismatch on {col}"
+
+
+def test_pbusinc_spouse_routes_to_spouse():
+    """MFJ: sbusinc/ssemp populate the spouse's self_employment_income while
+    psemp/pbusinc populate the primary's. A record with only sbusinc set must
+    put the income on the spouse, not the primary, so per-person SECA and QBID
+    are computed correctly."""
+    from policyengine_taxsim.runners.policyengine_runner import (
+        TaxsimMicrosimDataset,
+    )
+    from policyengine_us import Microsimulation
+
+    df = pd.DataFrame(
+        [
+            {
+                "taxsimid": 1,
+                "year": 2025,
+                "state": 44,
+                "mstat": 2,
+                "depx": 0,
+                "page": 45,
+                "sage": 45,
+                "pwages": 0.0,
+                "swages": 0.0,
+                "idtl": 2,
+                "sbusinc": 80_000.0,
+            }
+        ]
+    )
+    for col in _INCOME_COLS:
+        if col not in df.columns:
+            df[col] = 0.0
+    ds = TaxsimMicrosimDataset(df)
+    ds.generate()
+    sim = Microsimulation(dataset=ds)
+    se = np.array(sim.calculate("self_employment_income", 2025))
+    # Two people: primary (index 0) gets 0, spouse (index 1) gets 80k.
+    assert len(se) == 2
+    np.testing.assert_allclose(se, [0.0, 80_000.0])

--- a/tests/test_spouse_income_splitting.py
+++ b/tests/test_spouse_income_splitting.py
@@ -55,7 +55,7 @@ def _base_mfj_record(taxsimid=1, **overrides):
         ("dividends", "qualified_dividend_income", 80000),
         ("ltcg", "long_term_capital_gains", 60000),
         ("stcg", "short_term_capital_gains", 30000),
-        ("scorp", "s_corp_income", 50000),
+        ("scorp", "partnership_s_corp_income", 50000),
     ],
 )
 def test_mfj_household_income_splits_between_spouses(taxsim_field, pe_var, amount):
@@ -67,15 +67,28 @@ def test_mfj_household_income_splits_between_spouses(taxsim_field, pe_var, amoun
     np.testing.assert_allclose(values, [amount / 2, amount / 2])
 
 
-def test_scorp_maps_to_s_corp_income_not_partnership():
-    """TAXSIM `scorp` is S-corporation income, which is not subject to
-    self-employment tax. It must map to the `s_corp_income` leaf, not the
-    partnership leaf (taxsim #977, coordinating with policyengine-us#8613).
-    `partnership_income` should stay 0."""
+def test_scorp_maps_to_partnership_s_corp_income():
+    """TAXSIM `scorp` maps to `partnership_s_corp_income`, the variable named
+    in the § 199A QBI `income_definition`, so S-corp income earns the QBID.
+
+    Previously `scorp` mapped to the `s_corp_income` leaf. In the emulator's
+    dataset every mapped PE variable is set as an input, so holding the leaf
+    (a) suppressed its own uprating formula and (b) — combined with
+    `qualified_business_income` also being held at 0 by the old `pbusinc`
+    mapping — produced correct AGI but *no* QBID for S-corp income (Dan
+    Feenberg's 2026-06-30 five-source comparison; taxsim #943/#1004/#1018).
+
+    `partnership_s_corp_income` `adds` partnership_income + s_corp_income, so
+    setting it as an input leaves both leaves at 0 while the aggregate carries
+    the value into the QBI base. S-corp income remains free of self-employment
+    tax (no SECA), consistent with the earlier taxsim #977 intent that scorp
+    not be treated as active partnership income."""
     df = pd.DataFrame([_base_mfj_record(scorp=50000)])
-    s_corp = _run_allocation(df, "s_corp_income")
+    partnership_s_corp = _run_allocation(df, "partnership_s_corp_income")
     partnership = _run_allocation(df, "partnership_income")
-    np.testing.assert_allclose(s_corp, [25000.0, 25000.0])
+    np.testing.assert_allclose(partnership_s_corp, [25000.0, 25000.0])
+    # The value lives in the aggregate; the partnership leaf stays 0 so scorp
+    # is never misclassified as active partnership income subject to SECA.
     np.testing.assert_allclose(partnership, [0.0, 0.0])
 
 


### PR DESCRIPTION
## Summary

TAXSIM pass-through income sources produced the wrong federal tax in the emulator's PolicyEngine column. In Dan Feenberg's 2026-06-30 five-source comparison (`$100k` gross from each of five sources, 2025 single filer):

| source | PE before (AGI / taxable / tax) | TAXSIM-35 (AGI / taxable / tax) | status before |
|--------|--------------------------------|--------------------------------|---------------|
| `psemp` (self-employment) | 92,935 / **77,185** / 11,895 | 92,935 / 61,748 / 8,498 | correct AGI, **no QBID** |
| `scorp` (S-corp) | 100,000 / **84,250** / 13,449 | 100,000 / 67,400 / 9,742 | correct AGI, **no QBID** |
| `pbusinc` (active QBI) | **0 / 0 / 0** | 92,935 / 61,748 / 8,498 | **unmapped** |
| `pprofinc` (SSTB) | 92,935 / 61,748 / 8,499 | 92,935 / 61,748 / 8,498 | already correct |
| `intrec` (interest) | 100,000 / 84,250 / 13,449 | 100,000 / 84,250 / 13,449 | already correct |

**policyengine-us itself is correct.** A direct `Simulation` with `self_employment_income = 100_000` gives AGI 92,935 / taxable 61,748 / income_tax 8,499 (QBID and half-SECA exact); `partnership_s_corp_income = 100_000` gives AGI 100,000 / taxable 67,400 / income_tax 9,742 (no SECA, QBID, NIIT-eligible). The defect was entirely in this emulator's mapping layer.

## Root cause (per variable)

The emulator builds a dataset in which **every mapped PolicyEngine variable is set as an input**. When a variable is supplied as a dataset input, PolicyEngine does not run its formula — it holds the supplied value.

- **`pbusinc` -> `qualified_business_income`.** `qualified_business_income` is a **computed** variable (`defined_for = "business_is_qualified"`) derived from `self_employment_income` + `partnership_s_corp_income` + `rental_income` + ... via the § 199A `income_definition` parameter. Mapping `pbusinc` to it made it a held input — pinned to whatever `pbusinc` supplied, i.e. **0 on every record that had no `pbusinc`**. That zeroed the *non-SSTB QBI component for all records*, so `psemp` and `scorp` lost their QBID too. On the `pbusinc` record itself, the value sat in `qualified_business_income` but never entered AGI (it is not in the gross-income build), so AGI/taxable/tax were all 0.
- **`psemp`/`ssemp` -> `self_employment_income`** was already the right target, but the non-SSTB QBI component was being zeroed by the `qualified_business_income` holdout above -> QBID = 0 (taxable 77,185 instead of 61,748).
- **`scorp` -> `s_corp_income`** (leaf). The QBI `income_definition` names `partnership_s_corp_income` (which `adds` `partnership_income` + `s_corp_income`), not the `s_corp_income` leaf. Holding the leaf suppressed its own uprating formula, and — combined with the `qualified_business_income` holdout — S-corp income produced correct AGI but no QBID.
- **`pprofinc`/`sprofinc` -> `sstb_self_employment_income`** was already correct: `sstb_self_employment_income` is a dedicated input whose SSTB QBI (`sstb_qualified_business_income`) is *computed* (not held), so it earned the § 199A(d)(3)-phaseout QBID. Unchanged.

## Fix

`config/variable_mappings.yaml` plus the two mapper code paths (`core/input_mapper.py` single-household path and `runners/policyengine_runner.py` Microsimulation path):

- `psemp`/`ssemp` **and** `pbusinc`/`sbusinc` -> `self_employment_income` (active participation, SECA, QBID **without** the SSTB phaseout). Per Dan's spec, `businc` is identical to `semp`, so they share one variable; the mapper sums each spouse's own pair (`psemp + pbusinc` -> primary, `ssemp + sbusinc` -> spouse). Removing `qualified_business_income` from the mapping lets it be computed again.
- `scorp` -> `partnership_s_corp_income` (QBID, no SECA, NIIT-eligible).
- `pprofinc`/`sprofinc` -> `sstb_self_employment_income` (unchanged).

`sbusinc` is added to the recognized input columns (`api.py`, `taxsim_runner.py`). The S-corp splitting entry in `test_spouse_income_splitting.py` is updated to the new mapping (the value now lives in `partnership_s_corp_income`; the `partnership_income` leaf stays 0 so S-corp income is never treated as active partnership income).

### After the fix (emulator PolicyEngine column, TX 2025 single, `$100k` each)

| source | AGI | taxable | income_tax | QBID | FICA |
|--------|-----|---------|-----------|------|------|
| `psemp` | 92,935 | 61,748 | 8,499 | 15,437 | 14,130 |
| `scorp` | 100,000 | 67,400 | 9,742 | 16,850 | 0 |
| `pbusinc` | 92,935 | 61,748 | 8,499 | 15,437 | 14,130 |
| `pprofinc` | 92,935 | 61,748 | 8,499 | 15,437 | 14,130 |
| `intrec` | 100,000 | 84,250 | 13,449 | 0 | 0 |

All five now match TAXSIM-35 (within the ±1 rounding of the half-SECA/QBID chain).

## Tests

New `tests/test_passthrough_qbid.py` (16 tests):
- reproduces Dan's five-source table, asserting AGI / taxable income / federal income tax for each source;
- asserts QBID is present for the four pass-through sources and absent for interest;
- asserts `scorp` bears no SECA/FICA while still earning a QBID, and that `psemp`/`pbusinc`/`pprofinc` bear SECA;
- asserts `pbusinc` and `psemp` are identical (Dan's spec);
- pins the SSTB phaseout: at `$260k` single, `pprofinc` (SSTB) QBID (~5,983) is strictly and materially below `pbusinc` (non-SSTB) QBID (~17,143), and at `$300k` the SSTB QBID is fully eliminated;
- verifies MFJ routing (`sbusinc` lands on the spouse's `self_employment_income`).

`tests/test_spouse_income_splitting.py` updated for the `scorp -> partnership_s_corp_income` mapping.

## SSTB / `business_is_sstb` note

`pprofinc` already routes to `sstb_self_employment_income`, which earns the QBID **with** the § 199A(d)(3) applicable-percentage phaseout without needing the `business_is_sstb` flag (that flag exists for callers who set the legacy `qualified_business_income` and want it treated as SSTB). No `business_is_sstb` change was needed on the `pprofinc` path.

## Points for Dan

1. **`pbusinc`/`sbusinc` columns.** The current repo `input_definition` labeled `pbusinc` "Primary and secondary Taxpayer's active QBI" (a single combined column). The NBER TAXSIM-35 docs and your 2026-06-30 email both use per-spouse columns (`pbusinc` = primary, `sbusinc` = spouse; `sbusinc` "must be zero for non-joint returns"). This PR follows the per-spouse convention: `pbusinc` -> primary, `sbusinc` -> spouse (added). If `taxsimtest` today only accepts a combined `pbusinc`, the primary-person mapping still gives the right single-filer answer; flag it and I'll adjust.
2. **`businc` == `semp` redundancy.** As you noted, `pbusinc` and `psemp` are, by your spec, the same thing (active + SECA + QBID-without-phaseout). This PR maps them to the same PolicyEngine variable, so they are now genuinely interchangeable.
3. **Passive losses & material participation (#762, #943, #1003, #1018).** This PR fixes the positive-income QBID routing but does not implement passive-loss limitations or an explicit passive/material-participation flag for `scorp`. `scorp -> partnership_s_corp_income` gives QBID-without-phaseout and no SECA, matching your #1018 suggestion; the loss-limitation and passive-classification questions remain open and are better settled with the tax-lawyer review you flagged.

## Issues

Fixes #1004 (PE did not allow QBID for `scorp`; it now does).
Addresses #384 (FICA and QBI income — QBID now flows; AL/MO FICA-deduction nuance untouched), #762 (QBID across the seven pass-through inputs — single-source cases fixed; passive losses open), #943 (`scorp` QBID/phaseout), #1018 (`scorp` characteristics), #1003 (joint pass-through with losses — loss limitation still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
