### PR TITLE
Map TAXSIM transfers to general_assistance (#455)

### DIFF
--- a/changelog.d/map-transfers-general-assistance.added.md
+++ b/changelog.d/map-transfers-general-assistance.added.md
@@ -1,0 +1,1 @@
+Map TAXSIM transfers (#19) to general_assistance so non-taxable transfer income flows into state property-tax-rebate household-income tests without affecting federal tax.

--- a/policyengine_taxsim/config/variable_mappings.yaml
+++ b/policyengine_taxsim/config/variable_mappings.yaml
@@ -826,6 +826,14 @@ taxsim_to_policyengine:
       - unemployment_compensation:
           - pui
           - sui
+      # TAXSIM `transfers` (#19) is non-taxable transfer income (welfare,
+      # workers comp, veterans benefits, child support) that affects state
+      # property-tax-rebate eligibility but is not federally taxable. Map it
+      # to `general_assistance` — a non-taxable input variable counted in
+      # state household-income tests (e.g. MI household resources) with no
+      # dependent/child-support side effects. See taxsim #455.
+      - general_assistance:
+          - transfers
 
 taxsim_input_definition:
   - taxsimid:

--- a/tests/test_transfers_mapping.py
+++ b/tests/test_transfers_mapping.py
@@ -1,0 +1,50 @@
+"""
+Tests for mapping TAXSIM `transfers` (#19) to PolicyEngine general_assistance.
+
+TAXSIM `transfers` is non-taxable transfer income (welfare, workers comp,
+veterans benefits, child support) that affects state property-tax-rebate
+eligibility but is not federally taxable. It maps to `general_assistance`,
+a non-taxable input variable counted in state household-income tests (e.g.
+Michigan household resources). See taxsim #455.
+"""
+
+import io
+
+import pandas as pd
+from click.testing import CliRunner
+
+from policyengine_taxsim.cli import cli
+
+
+def _row(state: int, transfers: float, extra: str = "pwages", extra_val: float = 30000.0):
+    record = (
+        f"taxsimid,year,state,mstat,page,sage,depx,{extra},transfers,idtl\n"
+        f"1,2025,{state},1,67,0,0,{extra_val},{transfers},2\n"
+    )
+    result = CliRunner().invoke(cli, [], input=record)
+    assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+    out = result.output
+    idx = out.find("taxsimid,")
+    assert idx != -1, f"No CSV output:\n{out}"
+    return pd.read_csv(io.StringIO(out[idx:])).iloc[0]
+
+
+def test_transfers_not_federally_taxable():
+    """transfers must not change federal AGI or federal tax (state=0)."""
+    r0 = _row(state=0, transfers=0)
+    r5 = _row(state=0, transfers=5000)
+    assert r0["fiitax"] == r5["fiitax"], "transfers changed federal tax"
+    assert r0["v10"] == r5["v10"], "transfers changed federal AGI"
+
+
+def test_transfers_flow_into_mi_household_resources():
+    """In Michigan, transfers raise total household resources, reducing the
+    refundable property-tax-rebate/home-heating credit (less negative siitax)."""
+    r0 = _row(state=23, transfers=0, extra="gssi", extra_val=928.58)
+    r5 = _row(state=23, transfers=5000, extra="gssi", extra_val=928.58)
+    # Higher household resources -> smaller refundable credit -> siitax rises
+    # toward 0 (becomes less negative).
+    assert r5["siitax"] > r0["siitax"], (
+        f"transfers did not reduce the MI credit: "
+        f"siitax {r0['siitax']} (t=0) vs {r5['siitax']} (t=5000)"
+    )

--- a/tests/test_transfers_mapping.py
+++ b/tests/test_transfers_mapping.py
@@ -16,7 +16,9 @@ from click.testing import CliRunner
 from policyengine_taxsim.cli import cli
 
 
-def _row(state: int, transfers: float, extra: str = "pwages", extra_val: float = 30000.0):
+def _row(
+    state: int, transfers: float, extra: str = "pwages", extra_val: float = 30000.0
+):
     record = (
         f"taxsimid,year,state,mstat,page,sage,depx,{extra},transfers,idtl\n"
         f"1,2025,{state},1,67,0,0,{extra_val},{transfers},2\n"


### PR DESCRIPTION
## Summary

TAXSIM `transfers` (#19) — *"other non-taxable transfer income that would affect eligibility for state property tax rebates but would not be taxable at the federal level"* (welfare, workers comp, veterans benefits, child support) — was **unmapped**, so the emulator silently ignored it.

This maps `transfers → general_assistance`, chosen because it is:
- **non-taxable federally** (correct — `transfers` never touches federal AGI/tax),
- **counted in state household-income tests** (e.g. Michigan total household resources, which feeds the Homestead Property Tax Credit and Home Heating Credit), and
- **free of side effects** — unlike `child_support_received` (spurious child-support exclusions/dependent logic) or `miscellaneous_income` (federally taxable). It also doesn't collide with the transfer variables zeroed in #1049 (ssi/snap/tanf/wic/state supplements).

`general_assistance` is a pure input variable, so the standard `variable_mappings.yaml` mechanism sets it cleanly (no `set_input` needed).

## Verification

- **Federal invariance:** a $5,000 `transfers` leaves federal AGI and `fiitax` unchanged.
- **State flow:** for a Michigan filer, `transfers` raises household resources and reduces the refundable property-tax-rebate/home-heating credit, as expected.

Adds `tests/test_transfers_mapping.py` (federal-non-taxable + MI household-resources flow).

Addresses @feenberg's suggestion on #1031 to wire `transfers` so it can be tested against the binary. Closes #455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)