### PR TITLE
Zero MD county/local income tax in the emulator to match TAXSIM

### DIFF
--- a/changelog.d/zero-md-local-tax-for-parity.fixed.md
+++ b/changelog.d/zero-md-local-tax-for-parity.fixed.md
@@ -1,0 +1,1 @@
+Zero PolicyEngine's Maryland county/local income tax in the emulator to match TAXSIM, whose MD siitax is state-only (it applies no county tax when the input carries no locality). MD is the only state with a residence-based local tax; other local-tax states already read $0 without a locality.

--- a/policyengine_taxsim/runners/policyengine_runner.py
+++ b/policyengine_taxsim/runners/policyengine_runner.py
@@ -1193,6 +1193,32 @@ class PolicyEngineRunner(BaseTaxRunner):
                         ),
                     )
 
+            # Maryland county/local income tax: TAXSIM's MD `siitax` is
+            # state-only — it applies no county tax when the input carries no
+            # locality (verified against the binary: TAXSIM MD siitax equals
+            # PE's state-only MD tax to the dollar). PE, by contrast, applies
+            # MD's *residence-based* county tax (~2.25-3.20%) to every MD
+            # resident even with no county specified, systematically
+            # over-stating MD siitax vs TAXSIM. The TAXSIM input has no county,
+            # so zero PE's MD local income tax to match TAXSIM's coverage. MD
+            # is the only state affected: every other local-income-tax state
+            # (OH/PA/IN/KY/MI/NYC/…) requires a locality PE isn't given, so
+            # those already compute $0 local and match TAXSIM.
+            if "state" in chunk_df.columns and (chunk_df["state"] == 21).any():
+                var = "md_local_income_tax_before_credits"
+                if var in sim.tax_benefit_system.variables:
+                    n_md = sim.get_variable_population(var).count
+                    for year in years:
+                        sim.set_input(
+                            variable_name=var,
+                            value=np.zeros(n_md),
+                            period=str(
+                                int(year)
+                                if isinstance(year, (float, np.floating))
+                                else year
+                            ),
+                        )
+
             return self._extract_vectorized_results(sim, chunk_df)
 
         finally:

--- a/tests/test_md_local_tax_parity.py
+++ b/tests/test_md_local_tax_parity.py
@@ -1,0 +1,41 @@
+"""
+Maryland county/local income tax parity with TAXSIM.
+
+TAXSIM's Maryland `siitax` is state-only: it applies no county tax when the
+input carries no locality. PolicyEngine applies MD's residence-based county
+tax (~2.25-3.20%) to every MD resident, over-stating MD siitax vs TAXSIM.
+Since the TAXSIM input has no county, the emulator zeros PE's MD local income
+tax to match TAXSIM's coverage. MD is the only state affected (every other
+local-income-tax state needs a locality that PE isn't given). See #1062.
+"""
+
+import io
+
+import pandas as pd
+from click.testing import CliRunner
+
+from policyengine_taxsim.cli import cli
+
+
+def _siitax(state: int, wage: int = 100000):
+    record = (
+        "taxsimid,year,state,mstat,page,sage,depx,pwages,idtl\n"
+        f"1,2025,{state},1,40,0,0,{wage},2\n"
+    )
+    result = CliRunner().invoke(cli, [], input=record)
+    assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+    out = result.output
+    idx = out.find("taxsimid,")
+    return pd.read_csv(io.StringIO(out[idx:]))["siitax"].iloc[0]
+
+
+def test_md_siitax_excludes_county_tax():
+    """MD (SOI 21) siitax should be state-only — the ~3% county tax is zeroed
+    to match TAXSIM (which applies no county tax absent a locality)."""
+    md = _siitax(21, 100000)
+    # State-only MD tax on $100k single (2025) ~= $4,386; with the county tax
+    # it would be ~$7,200. Assert it's the state-only figure.
+    assert 4000 < md < 5000, (
+        f"MD siitax {md} looks like it still includes the county tax "
+        "(state-only expected ~$4,386)"
+    )


### PR DESCRIPTION
## Summary
TAXSIM's Maryland `siitax` is **state-only** — it applies no county tax when the input has no locality. Verified against the binary: TAXSIM MD siitax equals PE's state-only MD tax **to the dollar** ($3,196 = $3,196; $2,812 = $2,812). PE, however, applies MD's **residence-based** county tax (~2.25–3.20%) to every MD resident even with no county specified, so PE's MD siitax runs ~3% of income high — the single systematic MD driver in the eCPS (#1062).

This zeros PE's `md_local_income_tax_before_credits` for MD records so MD siitax matches TAXSIM's coverage.

## Why MD only
MD's county tax is uniquely **residence-based** (every MD resident is in a taxing county). Every other local-income-tax state (OH/PA/IN/KY/MI/NYC/MO/AL/DE) requires a **locality** the TAXSIM input doesn't carry, so PE already computes **$0** local for them (verified) and they already match TAXSIM. So the fix is cleanly MD-specific.

## The trade-off (deliberate)
MD's county tax is a **real, mandatory** tax, so this trades a bit of standalone accuracy for **TAXSIM parity** — consistent with the emulator's purpose as a TAXSIM replacement, and with how it already matches TAXSIM's coverage elsewhere (e.g. transfer zeroing, #1049). Here PE was arguably the *more complete* number and TAXSIM omits the county tax; we align to TAXSIM because the input has no county to base a rate on.

## Verification
- MD $100k single: siitax **$7,218 → $4,386** (state-only, = TAXSIM). Non-MD (OH) unchanged.
- New test `tests/test_md_local_tax_parity.py`; full suite passes.

Resolves the MD cluster in #1062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)