### PR TITLE
Deflake the generate-phase performance test (floor timing denominator at 100ms)

### DIFF
--- a/changelog.d/fix-flaky-generate-perf-test.fixed.md
+++ b/changelog.d/fix-flaky-generate-perf-test.fixed.md
@@ -1,0 +1,1 @@
+Floor the generate-phase performance test's timing denominator at 100ms so scheduler noise on fast CI runners no longer flakes the 5x scaling assertion.

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -183,7 +183,13 @@ class TestGeneratePhaseEfficiency:
             times[n] = time.time() - t0
             dataset.cleanup()
 
-        ratio = times[500] / max(times[100], 0.01)
+        # Floor the denominator at 100ms: when the 100-record base runs in a
+        # few tens of milliseconds, scheduler noise dominates the ratio and
+        # the test flakes on CI (observed 5.3x/5.9x on runs where both
+        # absolute times were well under a quarter second). A genuinely
+        # pathological (e.g. quadratic row-loop) regression still trips the
+        # assertion because times[500] grows into whole seconds.
+        ratio = times[500] / max(times[100], 0.1)
         assert ratio < 5.0, (
             f"Generate phase scaled {ratio:.1f}x for 5x more records "
             f"(100: {times[100]:.2f}s, 500: {times[500]:.2f}s). "


### PR DESCRIPTION
\`test_generate_does_not_scale_linearly\` flaked twice this week on unrelated PRs (#1070: 5.3x on windows-3.10; #1072: 5.9x on macos-3.10) — in both cases the absolute times were tiny (e.g. 0.03s → 0.20s), where scheduler noise dominates the ratio. Floor the denominator at 100ms so sub-noise bases can't fail the 5x assertion; a genuinely pathological regression (row-loop/quadratic) still trips it because the 500-record time grows into whole seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)