### PR TITLE
Add --taxsim-opt30 flag to compare (PSL-conformance test mode)

### DIFF
--- a/changelog.d/add-taxsim-opt30-flag.added.md
+++ b/changelog.d/add-taxsim-opt30-flag.added.md
@@ -1,0 +1,1 @@
+Add a --taxsim-opt30 option to the compare command that runs the TAXSIM binary in its PSL-conformance test mode (option 30=1: rebates booked in the eligible year, no smoothing, no federal-state iteration), the mode NBER uses when testing PolicyEngine records.

--- a/policyengine_taxsim/cli.py
+++ b/policyengine_taxsim/cli.py
@@ -333,6 +333,20 @@ def taxsim(input_file, output, sample, taxsim_path):
         "comparison is unaffected."
     ),
 )
+@click.option(
+    "--taxsim-opt30",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run the TAXSIM binary in its PSL-conformance test mode by setting "
+        "global option 30=1 (which sets opt 27/88/91: rebates booked in the "
+        "eligible year like PolicyEngine, no smoothing, no federal-state "
+        "iteration, plus per-state concessions such as the MI heating "
+        "credit). This is the mode NBER uses when testing PolicyEngine "
+        "records; without it the binary runs in default production mode. "
+        "See https://taxsim.nber.org/taxsimtest/options.html"
+    ),
+)
 def compare(
     input_file,
     sample,
@@ -343,6 +357,7 @@ def compare(
     assume_w2_wages,
     rel_tolerance,
     net_of_rebates,
+    taxsim_opt30,
 ):
     """Compare PolicyEngine and TAXSIM results"""
     try:
@@ -394,6 +409,14 @@ def compare(
         click.echo("Running TAXSIM...")
         taxsim_input = df.copy()
         taxsim_input["taxsimid"] = df_with_ids["taxsimid"].values
+        if taxsim_opt30:
+            # TAXSIM options are global: setting opt(30)=1 on the records
+            # switches the whole run into PSL-conformance mode. Only add the
+            # columns when the input doesn't already carry option columns.
+            if "opt1" not in taxsim_input.columns:
+                taxsim_input["opt1"] = 30
+                taxsim_input["opt1v"] = 1
+            click.echo("Running TAXSIM with opt(30)=1 (PSL-conformance test mode)")
         taxsim_runner = TaxsimRunner(taxsim_input)
         taxsim_results = taxsim_runner.run()
 

--- a/tests/test_taxsim_opt30.py
+++ b/tests/test_taxsim_opt30.py
@@ -1,0 +1,48 @@
+"""
+Test for the --taxsim-opt30 compare flag.
+
+TAXSIM option 30=1 switches the binary into its PSL-conformance test mode
+(sets opt 27/88/91: rebates booked in the eligible year like PolicyEngine,
+no smoothing, no federal-state iteration, plus per-state concessions). NBER
+tests PolicyEngine records in this mode; default mode books one-time rebates
+in the payout year instead. See taxsim #1068.
+"""
+
+import io
+
+import pandas as pd
+from click.testing import CliRunner
+
+from policyengine_taxsim.cli import cli
+
+
+def _run_compare(tmp_path, extra_args):
+    """Run compare on a VA 2021 record whose $500 rebate timing differs
+    between TAXSIM's default (payout year) and PSL (eligible year) modes."""
+    input_csv = tmp_path / "va21.csv"
+    input_csv.write_text(
+        "taxsimid,year,state,mstat,page,sage,depx,pwages,idtl\n"
+        "1,2021,47,2,45,45,0,60000,2\n"
+    )
+    out_dir = tmp_path / "out"
+    result = CliRunner().invoke(
+        cli,
+        ["compare", str(input_csv), "--output-dir", str(out_dir)] + extra_args,
+    )
+    assert result.exit_code == 0, f"compare failed: {result.output}\n{result.exception}"
+    df = pd.read_csv(out_dir / "comparison_results_2021.csv")
+    taxsim = df[df.source == "taxsim"].iloc[0]
+    pe = df[df.source == "policyengine"].iloc[0]
+    return result.output, taxsim, pe
+
+
+def test_opt30_aligns_rebate_timing(tmp_path):
+    """With --taxsim-opt30 the binary books VA's 2021-liability rebate in
+    2021 (like PolicyEngine), so the two engines agree exactly."""
+    output, taxsim, pe = _run_compare(tmp_path, ["--taxsim-opt30"])
+    assert "opt(30)=1" in output
+    # Binary books the $500 rebate in the eligible year -> matches PE.
+    assert abs(taxsim["siitax"] - pe["siitax"]) < 1.0, (
+        f"opt30 run should align: TAXSIM {taxsim['siitax']} vs PE {pe['siitax']}"
+    )
+    assert taxsim["srebate"] > 400  # the rebate is reported in-year


### PR DESCRIPTION
## Summary
Adds `compare --taxsim-opt30`, which runs the TAXSIM binary with **global option 30=1** — the PSL-conformance test mode NBER uses when testing PolicyEngine records ([options.html](https://taxsim.nber.org/taxsimtest/options.html)). It sets opt 27 (one-time rebates booked in the **eligible year**, PolicyEngine's convention), opt 88/91 (no smoothing, no federal↔state iteration), and per-state concessions (e.g. the MI heating credit).

## Why
Our bulk comparisons ran the binary in default production mode while @feenberg's record-level testing runs opt30 — so several apparent discrepancies measured the **mode difference**, not engine disagreement (#1068 rebate clusters; #1050 MI HHC, withdrawn — opt30 matches PE to the penny; #1071 OR kicker — absent under opt30). This flag closes the loop promised on those threads: comparisons can now measure the same mode Dan tests.

## Verification
VA 2021 joint ($60k wages; $500 rebate keyed to 2021 liability, paid 2022):
| | TAXSIM siitax | PE siitax | match |
|---|---|---|---|
| default | 2,568.05 (payout-year) | 2,068.05 | ❌ |
| `--taxsim-opt30` | **2,068.05** (srebate 500 in-year) | 2,068.05 | ✅ exact |

Options are injected as `opt1/opt1v` columns (skipped if the input already carries option columns); TAXSIM options are global so the whole run switches mode. Test: `tests/test_taxsim_opt30.py` (e2e via the compare CLI). Composable with `--rel-tolerance` / `--net-of-rebates` (the latter mainly matters for default-mode runs).

Refs #1068, #1050, #1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)