### PR TITLE
Mark opt30 rebate-timing test xfail pending NBER clarification (#1089)

### DIFF
--- a/changelog.d/opt30-test-binary-drift.fixed.md
+++ b/changelog.d/opt30-test-binary-drift.fixed.md
@@ -1,0 +1,1 @@
+Mark the opt30 rebate-timing test xfail while NBER clarifies a taxsim-latest behavior change (VA 2021 rebate no longer booked in the eligible year under opt 30; taxsim #1089); keep asserting the flag plumbing.

--- a/tests/test_taxsim_opt30.py
+++ b/tests/test_taxsim_opt30.py
@@ -11,6 +11,7 @@ in the payout year instead. See taxsim #1068.
 import io
 
 import pandas as pd
+import pytest
 from click.testing import CliRunner
 
 from policyengine_taxsim.cli import cli
@@ -36,6 +37,18 @@ def _run_compare(tmp_path, extra_args):
     return result.output, taxsim, pe
 
 
+def test_opt30_flag_reaches_binary(tmp_path):
+    """--taxsim-opt30 must set opt(30)=1 on the TAXSIM run."""
+    output, _, _ = _run_compare(tmp_path, ["--taxsim-opt30"])
+    assert "opt(30)=1" in output
+
+
+@pytest.mark.xfail(
+    reason="taxsim-latest stopped booking the VA 2021 rebate in the eligible "
+    "year under opt(30) around 2026-07-08 (now siitax=2568.05, srebate=0); "
+    "awaiting NBER clarification in taxsim #1089",
+    strict=False,
+)
 def test_opt30_aligns_rebate_timing(tmp_path):
     """With --taxsim-opt30 the binary books VA's 2021-liability rebate in
     2021 (like PolicyEngine), so the two engines agree exactly."""


### PR DESCRIPTION
## Summary

Main's CI has been red since the #1074 merge commit (July 8): `test_opt30_aligns_rebate_timing` fails on every platform because `taxsim-latest` (downloaded fresh each CI run) changed behavior. With opt(30)=1, the VA 2021 anchor record now returns **siitax = 2568.05 with srebate = 0** — the $500 rebate is neither booked in the eligible year (the #1068 PSL-mode premise the test asserted) nor reported in `srebate`. PolicyEngine's side is unchanged (2068.05 + srebate 500). Reproduced locally with today's binary:

```
taxsimid,year,state,mstat,page,sage,depx,pwages,idtl
1,2021,47,2,45,45,0,60000,2
```

| source | siitax | srebate |
|---|---|---|
| taxsim (opt 30) | 2568.05 | 0.0 |
| policyengine | 2068.05 | 500.0 |

Asked NBER whether this is intentional in #1089 (it may relate to Dan's rebate-timing comments in #1084/#1088). Until then:

- keep a plumbing test asserting `opt(30)=1` reaches the binary;
- xfail the timing-alignment test with `strict=False`, so it flips back to passing automatically if the binary reverts.

Unblocks CI for open PRs (e.g. #1065).

## Test plan

- [x] `pytest tests/test_taxsim_opt30.py` — 1 passed, 1 xfailed
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)